### PR TITLE
pass args as string instead of Javascript Object

### DIFF
--- a/util/deploy.js
+++ b/util/deploy.js
@@ -373,7 +373,7 @@ function doDeployment(codeId, constructors, walletLabel, deploymentLabel, chainI
     'wasm',
     'instantiate',
     codeId,
-    args,
+    JSON.stringify(args),
     '--from',
     walletLabel,
     '--label',


### PR DESCRIPTION
The CLI doesn’t seem to work if we pass a JavaScript object