### PR TITLE
Use cargo locate-project to find config.json

### DIFF
--- a/constants/config.js
+++ b/constants/config.js
@@ -8,7 +8,7 @@ async function getConfig() {
 }
 
 async function getConfigPath() {
-  const source = spawn('git', ['rev-parse','--show-toplevel'], { stdio: ['inherit','pipe','inherit'] });
+  const source = spawn('cargo', ['locate-project', '--message-format', 'plain'], { stdio: ['inherit', 'pipe', 'inherit'] });
 
   for await (const data of source.stdout) {
     let topLevel = Buffer.from(data).toString().trim();


### PR DESCRIPTION
Using `git` will alway resolve to the root of the project, but usually, the config.json file is on the same level as `Cargo.toml`. Using `cargo` to resolve the path will fix this issue and allow storing the smart contract code in a sub folder inside the repository.