### PR TITLE
Update faucet request params to use coins array with denom

### DIFF
--- a/src/commands/faucet.js
+++ b/src/commands/faucet.js
@@ -9,7 +9,7 @@ const { Testnets, loadNetworkConfig } = require('../networks');
 const { isArchwayAddress } = require('../util/validators');
 
 async function sendRequest(address, faucet, feeDenom) {
-  const request = { denom: feeDenom, address };
+  const request = { coins: ['10000000' + feeDenom], address: address };
   const response = await HttpClient.post(faucet, request);
 
   const { status, data } = response;


### PR DESCRIPTION
This branch includes a small change that fixes the faucet request parameters

Old request params:
```js
const request = { denom: feeDenom, address };
```

New request params:
```js
const request = { coins: ['10000000' + feeDenom], address: address };
```