### PR TITLE
Cache calls to archwayd.keys.getAddress()

### DIFF
--- a/src/clients/archwayd/keys.js
+++ b/src/clients/archwayd/keys.js
@@ -1,7 +1,9 @@
+const _ = require('lodash');
 const { isArchwayAddress } = require('../../util/validators');
 
 class KeysCommands {
   #client;
+  #getAddressCache;
 
   constructor(client) {
     this.#client = client;
@@ -16,11 +18,17 @@ class KeysCommands {
   }
 
   async getAddress(name) {
-    const archwayd = this.#client.run('keys', ['show', name, '-a'], { stdio: ['inherit', 'pipe', 'inherit'] });
-    archwayd.stdout.pipe(process.stdout);
-    const { stdout } = await archwayd;
-    const lines = stdout.replace(/\r/g, '').split('\n');
-    return lines.find(isArchwayAddress);
+    if (!_.isFunction(this.#getAddressCache)) {
+      this.#getAddressCache = _.memoize(async (name) => {
+        const archwayd = this.#client.run('keys', ['show', name, '-a'], { stdio: ['inherit', 'pipe', 'inherit'] });
+        archwayd.stdout.pipe(process.stdout);
+        const { stdout } = await archwayd;
+        const lines = stdout.replace(/\r/g, '').split('\n');
+        return lines.find(isArchwayAddress);
+      });
+    }
+
+    return await this.#getAddressCache(name);
   }
 }
 


### PR DESCRIPTION
This will avoid asking for the key chain password many times when fetching the same address consecutively.