### PR TITLE
Bugfixes for Issue #42

### DIFF
--- a/src/commands/__tests__/new.test.js
+++ b/src/commands/__tests__/new.test.js
@@ -141,6 +141,87 @@ describe('project setup', () => {
     });
   });
 
+  test('converts snake case project name to lowercased kebab-case', async () => {
+    const name = {
+      raw:'archonauts_snake_case', 
+      normalized: 'archonauts-snake-case'
+    };
+
+    const cargo = spawk.spawn('cargo');
+
+    await New(name.raw, {
+      useTemplate: false,
+      docker: false,
+      environment: 'local',
+      build: false,
+    });
+
+    expect(cargo.calledWith).toMatchObject({
+      command: 'cargo',
+      args: expect.arrayContaining([
+        'generate',
+        '--name', name.normalized,
+        '--git', 'archway-network/archway-templates',
+        '--branch', 'main',
+        'default'
+      ])
+    });
+  });
+
+  test('converts camel case project name to lowercased kebab-case', async () => {
+    const name = {
+      raw:'archonautsCamelCase', 
+      normalized: 'archonautscamelcase'
+    };
+
+    const cargo = spawk.spawn('cargo');
+
+    await New(name.raw, {
+      useTemplate: false,
+      docker: false,
+      environment: 'local',
+      build: false,
+    });
+
+    expect(cargo.calledWith).toMatchObject({
+      command: 'cargo',
+      args: expect.arrayContaining([
+        'generate',
+        '--name', name.normalized,
+        '--git', 'archway-network/archway-templates',
+        '--branch', 'main',
+        'default'
+      ])
+    });
+  });
+
+  test('converts whitespaced project names to lowercased kebab-case', async () => {
+    const name = {
+      raw:'archonauts string case', 
+      normalized: 'archonauts-string-case'
+    };
+
+    const cargo = spawk.spawn('cargo');
+
+    await New(name.raw, {
+      useTemplate: false,
+      docker: false,
+      environment: 'local',
+      build: false,
+    });
+
+    expect(cargo.calledWith).toMatchObject({
+      command: 'cargo',
+      args: expect.arrayContaining([
+        'generate',
+        '--name', name.normalized,
+        '--git', 'archway-network/archway-templates',
+        '--branch', 'main',
+        'default'
+      ])
+    });
+  });
+
   test('generate project from network branch', async () => {
     const name = 'archonauts';
     const testnet = 'augusta';

--- a/src/commands/new.js
+++ b/src/commands/new.js
@@ -104,7 +104,7 @@ async function parseSettings(defaults) {
 function buildConfig({ name, docker, environment, testnet }) {
   const networkConfig = loadNetworkConfig(environment, testnet);
   const projectConfig = {
-    name: name,
+    name: name.toLowerCase().replace(/_/g, '-'),
     developer: {
       archwayd: { docker }
     }
@@ -142,10 +142,9 @@ async function initialCommit({ name }) {
 
 async function main(name, options = {}) {
   console.info(`Creating new Archway project...`);
-
   try {
-    const { network: { chainId } } = await createProject({ name, ...options });
-    console.info(chalk`\n{green Successfully created project {cyan ${name}} with network configuration {cyan ${chainId}}}`);
+    const config = await createProject({ name, ...options });
+    console.info(chalk`\n{green Successfully created project {cyan ${config.name}} with network configuration {cyan ${config.network.chainId}}}`);
   } catch (e) {
     if (e instanceof PromptCancelledError) {
       console.warn(chalk`{yellow ${e.message}}`);

--- a/src/commands/new.js
+++ b/src/commands/new.js
@@ -104,7 +104,7 @@ async function parseSettings(defaults) {
 function buildConfig({ name, docker, environment, testnet }) {
   const networkConfig = loadNetworkConfig(environment, testnet);
   const projectConfig = {
-    name: name.toLowerCase().replace(/_/g, '-'),
+    name: name.toLowerCase().replace(/_/g, '-').replace(/ /g, '-'),
     developer: {
       archwayd: { docker }
     }


### PR DESCRIPTION
This PR fixes project naming errors for the `archway new` command, as mentioned in Issue #42 