### PR TITLE
Adds CLI version check to each command

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ const Config = require('./util/config');
 const { createClient } = require('./clients/archwayd');
 const { Environments, Testnets } = require('./networks');
 const { isJson, isProjectName, isArchwayAddress } = require('./util/validators');
+const { checkSemanticVersion } = require('./util/semvar');
 
 /**
  * Gets the version from package.json
@@ -80,6 +81,7 @@ Program
     options = await updateWithDockerOptions(options);
     const archwayd = await createClient({ checkHomePath: true, ...options });
     await Tools.Accounts(archwayd, options);
+    checkSemanticVersion();
   });
 
 // `archway build`
@@ -88,6 +90,7 @@ Program
   .description('Build current project')
   .action(async () => {
     await Tools.Build();
+    checkSemanticVersion();
   });
 
 // `archway configure`
@@ -103,6 +106,7 @@ Program
       let param = options.modify
       await Tools.Configure(true, param);
     }
+    checkSemanticVersion();
   });
 
 // `archway deploy`
@@ -123,6 +127,7 @@ Program
     options = await updateWithDockerOptions(options);
     const archwayd = await createClient({ checkHomePath: true, ...options });
     await Tools.Deploy(archwayd, options);
+    checkSemanticVersion();
   });
 
 // `archway faucet`
@@ -141,6 +146,7 @@ Program
     console.info(chalk`2. Send the following message in the {yellow 🚰｜faucet} channel\n`);
     console.info(chalk`{bold.white !faucet ${address || '<address>'}}\n`);
     console.info('The funds will be deposited to your account in a few minutes on all testnets.');
+    checkSemanticVersion();
   });
 
 // `archway history`
@@ -149,6 +155,7 @@ Program
   .description('Print deployments history')
   .action(async () => {
     await Tools.DeployHistory();
+    checkSemanticVersion();
   });
 
 // `archway deploy`
@@ -170,6 +177,7 @@ Program
     options = await updateWithDockerOptions(options);
     const archwayd = await createClient({ checkHomePath: true, ...options });
     await Tools.Metadata(archwayd, options);
+    checkSemanticVersion();
   });
 
 // `archway network`
@@ -181,6 +189,7 @@ Program
   .addOption(new Option('-t, --testnet <value>', 'Testnet to use for the project').choices(Testnets))
   .action(async (options) => {
     await Tools.Network(options);
+    checkSemanticVersion();
   });
 
 // `archway new`
@@ -197,6 +206,7 @@ Program
   .argument('[name]', 'Project name', parseProjectName)
   .action(async (name, options) => {
     await Tools.New(name, options);
+    checkSemanticVersion();
   });
 
 // `archway query`
@@ -234,6 +244,7 @@ Program
     };
 
     await Tools.Query(options.docker, args);
+    checkSemanticVersion();
   });
 
 // `archway script`
@@ -251,6 +262,7 @@ Program
     } catch (e) {
       console.error('Error running custom script', [options.script]);
     }
+    checkSemanticVersion();
   });
 
 // `archway test`
@@ -259,6 +271,7 @@ Program
   .description('Run unit tests')
   .action(async () => {
     await Tools.Test();
+    checkSemanticVersion();
   });
 
 // `archway tx`
@@ -276,6 +289,7 @@ Program
     options = await updateWithDockerOptions(options);
     const archwayd = await createClient({ checkHomePath: true, ...options });
     await Tools.Tx(archwayd, options);
+    checkSemanticVersion();
   });
 
 Program.parseAsync();

--- a/src/index.js
+++ b/src/index.js
@@ -81,7 +81,6 @@ Program
     options = await updateWithDockerOptions(options);
     const archwayd = await createClient({ checkHomePath: true, ...options });
     await Tools.Accounts(archwayd, options);
-    checkSemanticVersion();
   });
 
 // `archway build`
@@ -89,8 +88,7 @@ Program
   .command('build')
   .description('Build current project')
   .action(async () => {
-    await Tools.Build();
-    checkSemanticVersion();
+    await Tools.Build();  
   });
 
 // `archway configure`
@@ -106,7 +104,6 @@ Program
       let param = options.modify
       await Tools.Configure(true, param);
     }
-    checkSemanticVersion();
   });
 
 // `archway deploy`
@@ -127,7 +124,6 @@ Program
     options = await updateWithDockerOptions(options);
     const archwayd = await createClient({ checkHomePath: true, ...options });
     await Tools.Deploy(archwayd, options);
-    checkSemanticVersion();
   });
 
 // `archway faucet`
@@ -146,7 +142,6 @@ Program
     console.info(chalk`2. Send the following message in the {yellow 🚰｜faucet} channel\n`);
     console.info(chalk`{bold.white !faucet ${address || '<address>'}}\n`);
     console.info('The funds will be deposited to your account in a few minutes on all testnets.');
-    checkSemanticVersion();
   });
 
 // `archway history`
@@ -155,7 +150,6 @@ Program
   .description('Print deployments history')
   .action(async () => {
     await Tools.DeployHistory();
-    checkSemanticVersion();
   });
 
 // `archway deploy`
@@ -189,7 +183,6 @@ Program
   .addOption(new Option('-t, --testnet <value>', 'Testnet to use for the project').choices(Testnets))
   .action(async (options) => {
     await Tools.Network(options);
-    checkSemanticVersion();
   });
 
 // `archway new`
@@ -206,7 +199,6 @@ Program
   .argument('[name]', 'Project name', parseProjectName)
   .action(async (name, options) => {
     await Tools.New(name, options);
-    checkSemanticVersion();
   });
 
 // `archway query`
@@ -244,7 +236,6 @@ Program
     };
 
     await Tools.Query(options.docker, args);
-    checkSemanticVersion();
   });
 
 // `archway script`
@@ -262,7 +253,6 @@ Program
     } catch (e) {
       console.error('Error running custom script', [options.script]);
     }
-    checkSemanticVersion();
   });
 
 // `archway test`
@@ -271,7 +261,6 @@ Program
   .description('Run unit tests')
   .action(async () => {
     await Tools.Test();
-    checkSemanticVersion();
   });
 
 // `archway tx`
@@ -289,7 +278,10 @@ Program
     options = await updateWithDockerOptions(options);
     const archwayd = await createClient({ checkHomePath: true, ...options });
     await Tools.Tx(archwayd, options);
-    checkSemanticVersion();
   });
+
+Program.hook('postAction', () => {
+  checkSemanticVersion();
+});
 
 Program.parseAsync();

--- a/src/util/semvar.js
+++ b/src/util/semvar.js
@@ -1,0 +1,27 @@
+const { spawn } = require('child_process');
+const chalk = require('chalk');
+
+function getVersion() {
+  const { version } = require('../../package.json');
+  return version;
+}
+
+async function checkSemanticVersion() {
+  const version = getVersion();
+
+  let runScript = {
+    cmd: 'npm',
+    params: ['view', '@archwayhq/cli', 'version']
+  };
+
+  const source = await spawn(runScript.cmd, runScript.params);
+  source.stdout.setEncoding('utf8');
+  source.stdout.on('data', (remote)=> {
+    remote = remote.trim();
+    if (remote !== version) {
+      console.warn(chalk`{whiteBright A newer version of Archway CLI is available ({green.bold v${remote}})\nSupport for {green.bold v${version}} has ended. Install the latest version with {yellow.bold npm install -g @archwayhq/cli}}`);
+    }
+  });
+}
+
+module.exports = { checkSemanticVersion };


### PR DESCRIPTION
Adds a version check to each CLI command. If version does not match latest npm release, a warning message is displayed to the end user. Delivers Issue #68 

This PR is branched out of `develop`

### Workflow / Process:
- Runs after each CLI command has finished
- If the version does not match the latest npm release, displays a warning to the end user

***

### Current caveats:
- If we start supporting backwards versions (e.g. a legacy version is re-published to npm) the message would appear for users on newer versions, since the legacy version is now the most recently published version
- The warning message will appear during development and for bleeding edge users (e.g. users that installed development versions from GitHub, that are not yet published to npm)