### PR TITLE
Load templates from the `main` branch in the `new` command

### DIFF
--- a/src/commands/__tests__/new.test.js
+++ b/src/commands/__tests__/new.test.js
@@ -222,27 +222,6 @@ describe('project setup', () => {
     });
   });
 
-  test('generate project from network branch', async () => {
-    const name = 'archonauts';
-    const testnet = 'titus';
-
-    const cargo = spawk.spawn('cargo');
-
-    await New(name, {
-      useTemplate: false,
-      docker: false,
-      environment: 'testnet',
-      testnet,
-      build: false,
-    });
-
-    expect(cargo.calledWith).toMatchObject({
-      args: expect.arrayContaining([
-        '--branch', `network/${testnet}`
-      ])
-    });
-  });
-
   test('generate project from selected template subfolder', async () => {
     const name = 'archonauts';
     const template = 'increment';

--- a/src/commands/new.js
+++ b/src/commands/new.js
@@ -116,9 +116,8 @@ function buildConfig({ name, docker, environment, testnet }) {
   return _.defaultsDeep(projectConfig, networkConfig);
 }
 
-async function cargoGenerate({ name, network: { name: networkName, templatesBranch } }, { template = DefaultTemplate }) {
-  const branch = templatesBranch || (networkName ? `network/${networkName}` : DefaultTemplateBranch);
-  await new Cargo().generate(name, TemplatesRepository, branch, template);
+async function cargoGenerate({ name }, { template = DefaultTemplate }) {
+  await new Cargo().generate(name, TemplatesRepository, DefaultTemplateBranch, template);
 }
 
 async function cargoBuild({ name }, { build = true } = {}) {


### PR DESCRIPTION
When different versions of the protocol were running in each network (Titus and Constantine), we created separate branches in the templates repository with the respective `cosmwasm-std` versions that would work in each. Since both networks have been running the same version for a while, we no longer need this separation.

We might still add tags for the templates in the future, but for now, let's use the latest version available (rolling release).