### PR TITLE
fix: fail fast when transactions do not succeed

### DIFF
--- a/src/commands/instantiate.js
+++ b/src/commands/instantiate.js
@@ -89,7 +89,10 @@ async function instantiateContract(archwayd, config, {
 
   const bech32AdminAddress = await parseBech32Address(archwayd, adminAddress);
   const instantiateArgs = [codeId, args, '--label', label, '--admin', bech32AdminAddress];
-  const { txhash } = await archwayd.tx.wasm('instantiate', instantiateArgs, { chainId, node, ...options });
+  const { code, raw_log: rawLog, txhash } = await archwayd.tx.wasm('instantiate', instantiateArgs, { chainId, node, ...options });
+  if (code && code !== 0) {
+    throw new Error(`Transaction failed: code=${code}, ${rawLog}`);
+  }
   const contractAddress = await retry(
     () => archwayd.query.txEventAttribute(txhash, 'instantiate', '_contract_address', { node, printStdout: false }),
     { text: chalk`Waiting for tx {cyan ${txhash}} to confirm...` }

--- a/src/commands/metadata.js
+++ b/src/commands/metadata.js
@@ -94,7 +94,11 @@ async function setContractMetadata(archwayd, options = {}) {
   const { chainId, codeId, contract, contractMetadata, node, ...txOptions } = await parseTxOptions(config, options);
 
   console.info(chalk`Setting metadata for contract {cyan ${contract}} on {cyan ${chainId}}...`);
-  const { txhash } = await archwayd.tx.setContractMetadata(contract, contractMetadata, { chainId, node, ...txOptions });
+  const { code, raw_log: rawLog, txhash } = await archwayd.tx.setContractMetadata(contract, contractMetadata, { chainId, node, ...txOptions });
+  if (code && code !== 0) {
+    throw new Error(`Transaction failed: code=${code}, ${rawLog}`);
+  }
+
   await retry(
     async bail => {
       const { code, raw_log: rawLog } = await archwayd.query.tx(txhash, { node, printStdout: false });

--- a/src/commands/store.js
+++ b/src/commands/store.js
@@ -83,7 +83,11 @@ async function storeWasm(archwayd, config, { project: { wasm: { optimizedFilePat
     await copyFile(optimizedFilePath, remotePath);
   }
 
-  const { txhash } = await archwayd.tx.wasm('store', [optimizedFilePath], { from, chainId, node, ...options });
+  // eslint-disable-next-line camelcase
+  const { code, raw_log: rawLog, txhash } = await archwayd.tx.wasm('store', [optimizedFilePath], { from, chainId, node, ...options });
+  if (code && code !== 0) {
+    throw new Error(`Transaction failed: code=${code}, ${rawLog}`);
+  }
   const codeIdString = await retry(
     () => archwayd.query.txEventAttribute(txhash, 'store_code', 'code_id', { node, printStdout: false }),
     { text: chalk`Waiting for tx {cyan ${txhash}} to confirm...` }


### PR DESCRIPTION
If a transaction returns a status different than `0`, it shouldn't proceed to the transaction status query step.