### PR TITLE
fix(cargo): check current path to fetch metadata

### DIFF
--- a/src/clients/cargo.js
+++ b/src/clients/cargo.js
@@ -1,6 +1,5 @@
 const debug = require('debug')('cargo');
 const _ = require('lodash');
-const { dirname } = require('path');
 const path = require('path');
 const { spawn } = require('promisify-child-process');
 


### PR DESCRIPTION
The `archway-cli` fails to identify the correct target path when it is executed inside a cargo workspace setup. Instead of relying in path conventions, it should get the current manifest file path and compare with the project metadata to find the correct output path and project name.