### PR TITLE
refactor(cargo): parse metadata for workspaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "eslint-plugin-node": "^11.1.0",
         "jest": "^27.5",
         "jest-mock-console": "^1.2.3",
-        "spawk": "^1.7.1"
+        "spawk": "^1.8.0"
       },
       "engines": {
         "node": ">=14"
@@ -4712,9 +4712,9 @@
       }
     },
     "node_modules/spawk": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/spawk/-/spawk-1.7.1.tgz",
-      "integrity": "sha512-qkPqVdPp5ICEeSYKB/qCkwIBB0IWQuouEvYenQvpTq15fqSQgutpH453NjEImrpCWTwQwj2bQjGp8YGHapEiWw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/spawk/-/spawk-1.8.0.tgz",
+      "integrity": "sha512-/bqxBMj+ldGl/p/hjHW8VRL9DulNQV0bjvB2v6knpG6gq2Y+teLtjpjqpBXQq02o6CCVCeiFP4VjCs0CVlG8Jg==",
       "dev": true,
       "engines": {
         "node": ">=12.0.0"
@@ -8841,9 +8841,9 @@
       }
     },
     "spawk": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/spawk/-/spawk-1.7.1.tgz",
-      "integrity": "sha512-qkPqVdPp5ICEeSYKB/qCkwIBB0IWQuouEvYenQvpTq15fqSQgutpH453NjEImrpCWTwQwj2bQjGp8YGHapEiWw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/spawk/-/spawk-1.8.0.tgz",
+      "integrity": "sha512-/bqxBMj+ldGl/p/hjHW8VRL9DulNQV0bjvB2v6knpG6gq2Y+teLtjpjqpBXQq02o6CCVCeiFP4VjCs0CVlG8Jg==",
       "dev": true
     },
     "sprintf-js": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "eslint-plugin-node": "^11.1.0",
     "jest": "^27.5",
     "jest-mock-console": "^1.2.3",
-    "spawk": "^1.7.1"
+    "spawk": "^1.8.0"
   },
   "engines": {
     "node": ">=14"

--- a/src/clients/__tests__/fixtures/cargo-metadata-single.json
+++ b/src/clients/__tests__/fixtures/cargo-metadata-single.json
@@ -1,0 +1,217 @@
+{
+  "packages": [
+    {
+      "name": "archway-project",
+      "version": "0.1.0",
+      "id": "archway-project 0.1.0 (path+file:///tmp/test/archway-project)",
+      "license": null,
+      "license_file": null,
+      "description": null,
+      "source": null,
+      "dependencies": [
+        {
+          "name": "cosmwasm-std",
+          "source": "registry+https://github.com/rust-lang/crates.io-index",
+          "req": "^1.0.0",
+          "kind": null,
+          "rename": null,
+          "optional": false,
+          "uses_default_features": true,
+          "features": [],
+          "target": null,
+          "registry": null
+        },
+        {
+          "name": "cosmwasm-storage",
+          "source": "registry+https://github.com/rust-lang/crates.io-index",
+          "req": "^1.0.0",
+          "kind": null,
+          "rename": null,
+          "optional": false,
+          "uses_default_features": true,
+          "features": [],
+          "target": null,
+          "registry": null
+        },
+        {
+          "name": "cw-storage-plus",
+          "source": "registry+https://github.com/rust-lang/crates.io-index",
+          "req": "^0.16",
+          "kind": null,
+          "rename": null,
+          "optional": false,
+          "uses_default_features": true,
+          "features": [],
+          "target": null,
+          "registry": null
+        },
+        {
+          "name": "cw2",
+          "source": "registry+https://github.com/rust-lang/crates.io-index",
+          "req": "^0.16",
+          "kind": null,
+          "rename": null,
+          "optional": false,
+          "uses_default_features": true,
+          "features": [],
+          "target": null,
+          "registry": null
+        },
+        {
+          "name": "schemars",
+          "source": "registry+https://github.com/rust-lang/crates.io-index",
+          "req": "^0.8",
+          "kind": null,
+          "rename": null,
+          "optional": false,
+          "uses_default_features": true,
+          "features": [],
+          "target": null,
+          "registry": null
+        },
+        {
+          "name": "serde",
+          "source": "registry+https://github.com/rust-lang/crates.io-index",
+          "req": "^1.0",
+          "kind": null,
+          "rename": null,
+          "optional": false,
+          "uses_default_features": false,
+          "features": [
+            "derive"
+          ],
+          "target": null,
+          "registry": null
+        },
+        {
+          "name": "thiserror",
+          "source": "registry+https://github.com/rust-lang/crates.io-index",
+          "req": "^1.0",
+          "kind": null,
+          "rename": null,
+          "optional": false,
+          "uses_default_features": true,
+          "features": [],
+          "target": null,
+          "registry": null
+        },
+        {
+          "name": "cosmwasm-schema",
+          "source": "registry+https://github.com/rust-lang/crates.io-index",
+          "req": "^1.0.0",
+          "kind": "dev",
+          "rename": null,
+          "optional": false,
+          "uses_default_features": true,
+          "features": [],
+          "target": null,
+          "registry": null
+        },
+        {
+          "name": "criterion",
+          "source": "registry+https://github.com/rust-lang/crates.io-index",
+          "req": "^0.4",
+          "kind": "dev",
+          "rename": null,
+          "optional": false,
+          "uses_default_features": true,
+          "features": [],
+          "target": null,
+          "registry": null
+        },
+        {
+          "name": "plotters",
+          "source": "registry+https://github.com/rust-lang/crates.io-index",
+          "req": "^0.3",
+          "kind": "dev",
+          "rename": null,
+          "optional": false,
+          "uses_default_features": true,
+          "features": [],
+          "target": null,
+          "registry": null
+        }
+      ],
+      "targets": [
+        {
+          "kind": [
+            "cdylib",
+            "rlib"
+          ],
+          "crate_types": [
+            "cdylib",
+            "rlib"
+          ],
+          "name": "archway-project",
+          "src_path": "/tmp/test/archway-project/src/lib.rs",
+          "edition": "2018",
+          "doc": true,
+          "doctest": true,
+          "test": true
+        },
+        {
+          "kind": [
+            "example"
+          ],
+          "crate_types": [
+            "bin"
+          ],
+          "name": "schema",
+          "src_path": "/tmp/test/archway-project/examples/schema.rs",
+          "edition": "2018",
+          "doc": false,
+          "doctest": false,
+          "test": false
+        },
+        {
+          "kind": [
+            "bench"
+          ],
+          "crate_types": [
+            "bin"
+          ],
+          "name": "increment_benchmark",
+          "src_path": "/tmp/test/archway-project/benches/increment_benchmark.rs",
+          "edition": "2018",
+          "doc": false,
+          "doctest": false,
+          "test": false
+        }
+      ],
+      "features": {
+        "backtraces": [
+          "cosmwasm-std/backtraces"
+        ],
+        "library": []
+      },
+      "manifest_path": "/tmp/test/archway-project/Cargo.toml",
+      "metadata": {
+        "scripts": {
+          "optimize": "docker run --rm -v \"$(pwd)\":/code -e CARGO_TERM_COLOR=always --mount type=volume,source=\"$(basename \"$(pwd)\")_cache\",target=/code/target --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry cosmwasm/rust-optimizer:0.12.10\n"
+        }
+      },
+      "publish": null,
+      "authors": [
+        "Augusto Elesbão <aelesbao@users.noreply.github.com>"
+      ],
+      "categories": [],
+      "keywords": [],
+      "readme": "README.md",
+      "repository": null,
+      "homepage": null,
+      "documentation": null,
+      "edition": "2018",
+      "links": null,
+      "default_run": null,
+      "rust_version": null
+    }
+  ],
+  "workspace_members": [
+    "archway-project 0.1.0 (path+file:///tmp/test/archway-project)"
+  ],
+  "resolve": null,
+  "target_directory": "/tmp/test/archway-project/target",
+  "version": 1,
+  "workspace_root": "/tmp/test/archway-project",
+  "metadata": null
+}

--- a/src/clients/__tests__/fixtures/cargo-metadata-workspace.json
+++ b/src/clients/__tests__/fixtures/cargo-metadata-workspace.json
@@ -1,0 +1,363 @@
+{
+  "packages": [
+    {
+      "name": "foo",
+      "version": "0.1.0",
+      "id": "foo 0.1.0 (path+file:///tmp/test/archway-project/contracts/foo)",
+      "license": "Apache-2.0",
+      "license_file": null,
+      "description": null,
+      "source": null,
+      "dependencies": [
+        {
+          "name": "cosmwasm-schema",
+          "source": "registry+https://github.com/rust-lang/crates.io-index",
+          "req": "^1.1.9",
+          "kind": null,
+          "rename": null,
+          "optional": false,
+          "uses_default_features": true,
+          "features": [],
+          "target": null,
+          "registry": null
+        },
+        {
+          "name": "cosmwasm-std",
+          "source": "registry+https://github.com/rust-lang/crates.io-index",
+          "req": "^1.1.9",
+          "kind": null,
+          "rename": null,
+          "optional": false,
+          "uses_default_features": true,
+          "features": [],
+          "target": null,
+          "registry": null
+        },
+        {
+          "name": "cosmwasm-storage",
+          "source": "registry+https://github.com/rust-lang/crates.io-index",
+          "req": "^1.1.9",
+          "kind": null,
+          "rename": null,
+          "optional": false,
+          "uses_default_features": true,
+          "features": [],
+          "target": null,
+          "registry": null
+        },
+        {
+          "name": "cw-storage-plus",
+          "source": "registry+https://github.com/rust-lang/crates.io-index",
+          "req": "^1.0.1",
+          "kind": null,
+          "rename": null,
+          "optional": false,
+          "uses_default_features": true,
+          "features": [],
+          "target": null,
+          "registry": null
+        },
+        {
+          "name": "cw2",
+          "source": "registry+https://github.com/rust-lang/crates.io-index",
+          "req": "^0.16",
+          "kind": null,
+          "rename": null,
+          "optional": false,
+          "uses_default_features": true,
+          "features": [],
+          "target": null,
+          "registry": null
+        },
+        {
+          "name": "schemars",
+          "source": "registry+https://github.com/rust-lang/crates.io-index",
+          "req": "^0.8.10",
+          "kind": null,
+          "rename": null,
+          "optional": false,
+          "uses_default_features": true,
+          "features": [],
+          "target": null,
+          "registry": null
+        },
+        {
+          "name": "serde",
+          "source": "registry+https://github.com/rust-lang/crates.io-index",
+          "req": "^1.0.145",
+          "kind": null,
+          "rename": null,
+          "optional": false,
+          "uses_default_features": false,
+          "features": [
+            "derive"
+          ],
+          "target": null,
+          "registry": null
+        },
+        {
+          "name": "thiserror",
+          "source": "registry+https://github.com/rust-lang/crates.io-index",
+          "req": "^1.0.31",
+          "kind": null,
+          "rename": null,
+          "optional": false,
+          "uses_default_features": true,
+          "features": [],
+          "target": null,
+          "registry": null
+        },
+        {
+          "name": "cw-multi-test",
+          "source": "registry+https://github.com/rust-lang/crates.io-index",
+          "req": "^0.16",
+          "kind": "dev",
+          "rename": null,
+          "optional": false,
+          "uses_default_features": true,
+          "features": [],
+          "target": null,
+          "registry": null
+        }
+      ],
+      "targets": [
+        {
+          "kind": [
+            "cdylib",
+            "rlib"
+          ],
+          "crate_types": [
+            "cdylib",
+            "rlib"
+          ],
+          "name": "foo",
+          "src_path": "/tmp/test/archway-project/contracts/foo/src/lib.rs",
+          "edition": "2021",
+          "doc": true,
+          "doctest": true,
+          "test": true
+        },
+        {
+          "kind": [
+            "bin"
+          ],
+          "crate_types": [
+            "bin"
+          ],
+          "name": "schema",
+          "src_path": "/tmp/test/archway-project/contracts/foo/src/bin/schema.rs",
+          "edition": "2021",
+          "doc": true,
+          "doctest": false,
+          "test": true
+        }
+      ],
+      "features": {
+        "backtraces": [
+          "cosmwasm-std/backtraces"
+        ],
+        "library": []
+      },
+      "manifest_path": "/tmp/test/archway-project/contracts/foo/Cargo.toml",
+      "metadata": null,
+      "publish": null,
+      "authors": [
+        "Augusto Elesbão <aelesbao@users.noreply.github.com>"
+      ],
+      "categories": [],
+      "keywords": [],
+      "readme": null,
+      "repository": "https://github.com/archway-network/archway-project",
+      "homepage": "https://archway.io",
+      "documentation": null,
+      "edition": "2021",
+      "links": null,
+      "default_run": null,
+      "rust_version": null
+    },
+    {
+      "name": "bar",
+      "version": "0.1.0",
+      "id": "bar 0.1.0 (path+file:///tmp/test/archway-project/contracts/bar)",
+      "license": "Apache-2.0",
+      "license_file": null,
+      "description": null,
+      "source": null,
+      "dependencies": [
+        {
+          "name": "cosmwasm-schema",
+          "source": "registry+https://github.com/rust-lang/crates.io-index",
+          "req": "^1.1.9",
+          "kind": null,
+          "rename": null,
+          "optional": false,
+          "uses_default_features": true,
+          "features": [],
+          "target": null,
+          "registry": null
+        },
+        {
+          "name": "cosmwasm-std",
+          "source": "registry+https://github.com/rust-lang/crates.io-index",
+          "req": "^1.1.9",
+          "kind": null,
+          "rename": null,
+          "optional": false,
+          "uses_default_features": true,
+          "features": [],
+          "target": null,
+          "registry": null
+        },
+        {
+          "name": "cosmwasm-storage",
+          "source": "registry+https://github.com/rust-lang/crates.io-index",
+          "req": "^1.1.9",
+          "kind": null,
+          "rename": null,
+          "optional": false,
+          "uses_default_features": true,
+          "features": [],
+          "target": null,
+          "registry": null
+        },
+        {
+          "name": "cw-storage-plus",
+          "source": "registry+https://github.com/rust-lang/crates.io-index",
+          "req": "^1.0.1",
+          "kind": null,
+          "rename": null,
+          "optional": false,
+          "uses_default_features": true,
+          "features": [],
+          "target": null,
+          "registry": null
+        },
+        {
+          "name": "cw2",
+          "source": "registry+https://github.com/rust-lang/crates.io-index",
+          "req": "^0.16",
+          "kind": null,
+          "rename": null,
+          "optional": false,
+          "uses_default_features": true,
+          "features": [],
+          "target": null,
+          "registry": null
+        },
+        {
+          "name": "schemars",
+          "source": "registry+https://github.com/rust-lang/crates.io-index",
+          "req": "^0.8.10",
+          "kind": null,
+          "rename": null,
+          "optional": false,
+          "uses_default_features": true,
+          "features": [],
+          "target": null,
+          "registry": null
+        },
+        {
+          "name": "serde",
+          "source": "registry+https://github.com/rust-lang/crates.io-index",
+          "req": "^1.0.145",
+          "kind": null,
+          "rename": null,
+          "optional": false,
+          "uses_default_features": false,
+          "features": [
+            "derive"
+          ],
+          "target": null,
+          "registry": null
+        },
+        {
+          "name": "thiserror",
+          "source": "registry+https://github.com/rust-lang/crates.io-index",
+          "req": "^1.0.31",
+          "kind": null,
+          "rename": null,
+          "optional": false,
+          "uses_default_features": true,
+          "features": [],
+          "target": null,
+          "registry": null
+        },
+        {
+          "name": "cw-multi-test",
+          "source": "registry+https://github.com/rust-lang/crates.io-index",
+          "req": "^0.16",
+          "kind": "dev",
+          "rename": null,
+          "optional": false,
+          "uses_default_features": true,
+          "features": [],
+          "target": null,
+          "registry": null
+        }
+      ],
+      "targets": [
+        {
+          "kind": [
+            "cdylib",
+            "rlib"
+          ],
+          "crate_types": [
+            "cdylib",
+            "rlib"
+          ],
+          "name": "bar",
+          "src_path": "/tmp/test/archway-project/contracts/bar/src/lib.rs",
+          "edition": "2021",
+          "doc": true,
+          "doctest": true,
+          "test": true
+        },
+        {
+          "kind": [
+            "bin"
+          ],
+          "crate_types": [
+            "bin"
+          ],
+          "name": "schema",
+          "src_path": "/tmp/test/archway-project/contracts/bar/src/bin/schema.rs",
+          "edition": "2021",
+          "doc": true,
+          "doctest": false,
+          "test": true
+        }
+      ],
+      "features": {
+        "backtraces": [
+          "cosmwasm-std/backtraces"
+        ],
+        "library": []
+      },
+      "manifest_path": "/tmp/test/archway-project/contracts/bar/Cargo.toml",
+      "metadata": null,
+      "publish": null,
+      "authors": [
+        "Augusto Elesbão <aelesbao@users.noreply.github.com>"
+      ],
+      "categories": [],
+      "keywords": [],
+      "readme": null,
+      "repository": "https://github.com/archway-network/archway-project",
+      "homepage": "https://archway.io",
+      "documentation": null,
+      "edition": "2021",
+      "links": null,
+      "default_run": null,
+      "rust_version": null
+    }
+  ],
+  "workspace_members": [
+    "foo 0.1.0 (path+file:///tmp/test/archway-project/contracts/foo)",
+    "bar 0.1.0 (path+file:///tmp/test/archway-project/contracts/bar)"
+  ],
+  "resolve": null,
+  "target_directory": "/tmp/test/archway-project/target",
+  "version": 1,
+  "workspace_root": "/tmp/test/archway-project",
+  "metadata": null
+}

--- a/src/clients/cargo.js
+++ b/src/clients/cargo.js
@@ -12,6 +12,9 @@ class Cargo {
     this.#cwd = cwd || process.cwd();
   }
 
+  /**
+   * @private
+   */
   async locateProject() {
     const { stdout } = await this.#run(['locate-project', '--message-format', 'plain'], { stdio: 'pipe' });
     return path.dirname(stdout || '');
@@ -43,6 +46,9 @@ class Cargo {
     );
   }
 
+  /**
+   * @private
+   */
   async metadata() {
     const { stdout } = await this.#run([
       'metadata',
@@ -53,6 +59,13 @@ class Cargo {
     return JSON.parse(stdout);
   }
 
+  /**
+   * Parses the project metadata.
+   * If ran from a workspace, it will return the first package in the workspace.
+   * If ran from a package folder, it will return the current package metadata.
+   *
+   * @returns {Promise<{ name: string, version: string, wasm: { fileName: string, filePath: string, optimizedFilePath: string }, workspaceRoot: string, isWorkspace: boolean }>}
+   */
   async projectMetadata() {
     const { packages = [], target_directory: targetDirectory, workspace_root: workspaceRoot } = await this.metadata();
     const currentManifestPath = await this.locateProject();

--- a/src/util/config.js
+++ b/src/util/config.js
@@ -89,13 +89,19 @@ class Config {
 
   static async open(rootPath) {
     try {
-      rootPath = rootPath || await new Cargo().locateProject();
+      rootPath = rootPath || Config.#getWorkspaceRoot();
       const configPath = path.join(rootPath, ConfigFilename);
       const configData = require(configPath);
       return new Config(configData, configPath);
     } catch (e) {
       throw new Error(`Failed to open the project config file: make sure you are running the command from an Archway project directory`);
     }
+  }
+
+  static async #getWorkspaceRoot() {
+    const cargo = new Cargo();
+    const { workspaceRoot } = await cargo.projectMetadata();
+    return workspaceRoot;
   }
 }
 


### PR DESCRIPTION
This change enables the CLI to work correctly with cargo workspace projects.