### PR TITLE
fix(build): kill build containers running in the background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Bug Fixes
 
 * **build**: fixed error when the CosmWasm Optimizer image didn't exist in the local environment ([#155](https://github.com/archway-network/archway-cli/pull/155))
+* **build**: fixed error when a build container is already running in the background ([#157](https://github.com/archway-network/archway-cli/pull/157))
 
 ### Breaking Changes
 


### PR DESCRIPTION
If a user halts the build container while it's running (using Ctrl+C), the process won't exit, and the container will keep running. In this case, we need to kill any previous instance of the build container before rerunning the optimizer.