### PR TITLE
refactor(archwayd): use archwayd image v0.2.0 and connect to host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 * **networks**: change the default gas adjustment parameter to `1.5` instead of `1.2` ([#153](https://github.com/archway-network/archway-cli/pull/153))
 * **build**: updated the CosmWasm Optimizer image to `0.12.11` ([#155](https://github.com/archway-network/archway-cli/pull/155))
 * **build**: enable rust backtrace in optimizer ([#156](https://github.com/archway-network/archway-cli/pull/156))
+* **archwayd**: use the `archwaynetwork/archwayd:v0.2.0` tag by default ([#159](https://github.com/archway-network/archway-cli/pull/159))
+* **archwayd**: connect the container to the host network to allow interaction with a node running on the host machine ([#159](https://github.com/archway-network/archway-cli/pull/159))
 
 ### Bug Fixes
 

--- a/src/clients/archwayd/__tests__/index.test.js
+++ b/src/clients/archwayd/__tests__/index.test.js
@@ -125,10 +125,9 @@ describe('DockerArchwayClient', () => {
       const client = await createClient({ docker: true });
       expect(client.extraArgs).toEqual(expect.arrayContaining([
         'run',
-        '--pull',
-        'always',
         '--rm',
         '-it',
+        '--network=host',
         `--volume=${DefaultArchwaydHome}:/root/.archway`,
         `archwaynetwork/archwayd:${DefaultArchwaydVersion}`
       ]));
@@ -143,17 +142,6 @@ describe('DockerArchwayClient', () => {
       expect(client.extraArgs).toEqual(expect.arrayContaining([
         `--volume=${archwaydHome}:/root/.archway`,
         `archwaynetwork/archwayd:${archwaydVersion}`
-      ]));
-    });
-
-    test('uses testnet name as the image version when available', async () => {
-      const archwaydVersion = '0.0.1';
-      const testnet = 'titus';
-
-      const client = await createClient({ docker: true, testnet, archwaydVersion });
-
-      expect(client.extraArgs).toEqual(expect.arrayContaining([
-        `archwaynetwork/archwayd:${testnet}`
       ]));
     });
   });

--- a/src/clients/archwayd/index.js
+++ b/src/clients/archwayd/index.js
@@ -5,7 +5,7 @@ const KeysCommands = require('./keys');
 const QueryCommands = require('./query');
 const TxCommands = require('./tx');
 
-const DefaultArchwaydVersion = 'latest';
+const DefaultArchwaydVersion = 'v0.2.0';
 const DefaultArchwaydHome = `${process.env.HOME}/.archway`;
 
 class ArchwayRunError extends Error {
@@ -99,9 +99,9 @@ class ArchwayClient {
 }
 
 class DockerArchwayClient extends ArchwayClient {
-  constructor({ archwaydVersion = DefaultArchwaydVersion, testnet, ...options } = {}) {
+  constructor({ archwaydVersion = DefaultArchwaydVersion, ...options } = {}) {
     super(options);
-    this.archwaydVersion = testnet || archwaydVersion;
+    this.archwaydVersion = archwaydVersion;
   }
 
   get command() {
@@ -120,8 +120,6 @@ class DockerArchwayClient extends ArchwayClient {
   static #getDockerArgs(archwaydHome, archwaydVersion) {
     return [
       'run',
-      '--pull',
-      'always',
       '--rm',
       '-it',
       `--volume=${archwaydHome}:/root/.archway`,

--- a/src/clients/archwayd/index.js
+++ b/src/clients/archwayd/index.js
@@ -123,6 +123,7 @@ class DockerArchwayClient extends ArchwayClient {
       '--rm',
       '-it',
       `--volume=${archwaydHome}:/root/.archway`,
+      '--network=host',
       `archwaynetwork/archwayd:${archwaydVersion}`
     ];
   }

--- a/src/index.js
+++ b/src/index.js
@@ -21,8 +21,7 @@ function getVersion() {
 async function getDefaultsFromConfig() {
   try {
     const {
-      network: { name: networkName } = {},
-      developer: { archwayd: { docker = false, version: archwaydVersion = networkName } = {} } = {}
+      developer: { archwayd: { docker = false, version: archwaydVersion } = {} } = {}
     } = await Config.read();
     return { archwaydVersion, docker };
   } catch (e) {


### PR DESCRIPTION
Changes included:

  * To clarify version compatibility, use the `archwaynetwork/archwayd:v0.2.0` tag. If necessary, the developers can still overwrite this value in the `config.json` file.
  * The `archwayd` container will now connect to the host network. This allows interacting with a node running on the host machine.