### PR TITLE
fix(archwayd): print only relevant info on error

### DIFF
--- a/src/clients/archwayd/__tests__/index.test.js
+++ b/src/clients/archwayd/__tests__/index.test.js
@@ -94,7 +94,7 @@ describe('ArchwayClient', () => {
       expect(archwayd.calledWith).toMatchObject({
         command: client.command,
         args: ['--keyring-backend', 'test', 'keys', 'list', '--output', 'json'],
-        options: { stdio: 'pipe', maxBuffer: 1024 * 1024 }
+        options: { stdio: ['inherit', 'pipe', 'pipe'], maxBuffer: 1024 * 1024 }
       });
 
       expect(json).toMatchObject(output);

--- a/src/clients/archwayd/__tests__/tx.test.js
+++ b/src/clients/archwayd/__tests__/tx.test.js
@@ -59,7 +59,7 @@ describe('TxCommands', () => {
           '--gas-adjustment', defaultOptions.gas.adjustment,
           '--output', 'json',
         ],
-        options: { stdio: ['inherit', 'pipe', 'inherit'] }
+        options: { stdio: ['inherit', 'pipe', 'pipe'] }
       });
     });
 
@@ -92,7 +92,7 @@ describe('TxCommands', () => {
           '--gas-adjustment', defaultOptions.gas.adjustment,
           '--output', 'json',
         ],
-        options: { stdio: ['inherit', 'pipe', 'inherit'] }
+        options: { stdio: ['inherit', 'pipe', 'pipe'] }
       });
     });
   });
@@ -124,7 +124,7 @@ describe('TxCommands', () => {
           '--gas-adjustment', defaultOptions.gas.adjustment,
           '--output', 'json',
         ],
-        options: { stdio: ['inherit', 'pipe', 'inherit'] }
+        options: { stdio: ['inherit', 'pipe', 'pipe'] }
       });
     });
   });

--- a/src/clients/archwayd/query.js
+++ b/src/clients/archwayd/query.js
@@ -33,23 +33,31 @@ class QueryCommands {
     return `${gasUnitPrice.amount}${gasUnitPrice.denom}`;
   }
 
-  async #run(queryArgs = [], { node, flags = [], printStdout } = {}) {
+  async #run(queryArgs = [], { node, flags = [], ...options } = {}) {
     const args = [
       ...queryArgs,
       '--node', node,
       ...flags
     ];
-    const { stdout } = await this.#client.run('query', args, { stdio: ['inherit', 'pipe', 'inherit'], printStdout });
+    const { stdout } = await this.#client.run(
+      'query',
+      args,
+      { printStdout: false, ...options, stdio: ['inherit', 'pipe', 'inherit'] }
+    );
     return stdout;
   }
 
-  async #runJson(queryArgs = [], { node, flags = [], printStdout } = {}) {
+  async #runJson(queryArgs = [], { node, flags = [], ...options } = {}) {
     const args = [
       ...queryArgs,
       '--node', node,
       ...flags
     ];
-    return await this.#client.runJson('query', args, { stdio: ['inherit', 'pipe', 'inherit'], printStdout });
+    return await this.#client.runJson(
+      'query',
+      args,
+      { printStdout: false, ...options, stdio: ['inherit', 'pipe', 'pipe'] }
+    );
   }
 }
 

--- a/src/clients/archwayd/tx.js
+++ b/src/clients/archwayd/tx.js
@@ -6,20 +6,20 @@ class TxCommands {
   }
 
   async wasm(wasmCommand, wasmArgs, options) {
-    return await this.#run([
+    return await this.#runJson([
       'wasm', wasmCommand, ...wasmArgs,
     ], options);
   }
 
   async setContractMetadata(contract, { ownerAddress, rewardsAddress }, options) {
-    return await this.#run([
+    return await this.#runJson([
       'rewards', 'set-contract-metadata', contract,
       ...(ownerAddress ? ['--owner-address', ownerAddress] : []),
       ...(rewardsAddress ? ['--rewards-address', rewardsAddress] : []),
     ], options);
   }
 
-  async #run(txArgs = [], { gas = {}, from, chainId, node, flags = [], printStdout } = {}) {
+  async #runJson(txArgs = [], { gas = {}, from, chainId, node, flags = [], ...options } = {}) {
     const gasFlags = await this.#getGasFlags(gas, { node });
     const args = [
       ...txArgs,
@@ -30,7 +30,7 @@ class TxCommands {
       ...gasFlags,
       ...flags
     ];
-    return await this.#client.runJson('tx', args, { stdio: ['inherit', 'pipe', 'inherit'], printStdout });
+    return await this.#client.runJson('tx', args, { printStdout: false, ...options });
   }
 
   async #getGasFlags({ mode = 'auto', prices: defaultGasPrices, adjustment = 1.2 }, options) {
@@ -44,9 +44,9 @@ class TxCommands {
 
   async #getMinimumConsensusFee(options) {
     try {
-      return await this.#client.query.rewardsEstimateFees(1, { printStdout: false, ...options });
+      return await this.#client.query.rewardsEstimateFees(1, options);
     } catch (e) {
-      return null;
+      return undefined;
     }
   }
 }

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -82,6 +82,9 @@ async function deploy(archwayd, { build = true, ...options } = {}) {
   await Instantiate(archwayd, deployOptions);
 }
 
+/**
+ * @deprecated since v1.2.0
+ */
 async function main(archwayd, options = {}) {
   try {
     console.warn(chalk`{yellow {bold WARNING:} This command is deprecated and will be removed in future versions}`);
@@ -98,9 +101,8 @@ async function main(archwayd, options = {}) {
       console.warn(chalk`{yellow ${e.message}}`);
     } else {
       console.error(chalk`\n{red.bold Failed to deploy project}`);
-      console.error(chalk`\n{red ${e.message}}`);
-      throw e;
     }
+    throw e;
   }
 }
 

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -1,5 +1,3 @@
-// archway-cli/util/index.js
-
 const Accounts = require('./accounts');
 const Build = require('./build');
 const Config = require('./config');

--- a/src/commands/instantiate.js
+++ b/src/commands/instantiate.js
@@ -94,7 +94,7 @@ async function instantiateContract(archwayd, config, {
     throw new Error(`Transaction failed: code=${code}, ${rawLog}`);
   }
   const contractAddress = await retry(
-    () => archwayd.query.txEventAttribute(txhash, 'instantiate', '_contract_address', { node, printStdout: false }),
+    () => archwayd.query.txEventAttribute(txhash, 'instantiate', '_contract_address', { node }),
     { text: chalk`Waiting for tx {cyan ${txhash}} to confirm...` }
   );
   if (!txhash || !contractAddress) {
@@ -137,7 +137,6 @@ async function main(archwayd, options = {}) {
       console.warn(chalk`{yellow ${e.message}}`);
     } else {
       console.error(chalk`\n{red.bold Failed to instantiate contract}`);
-      console.error(chalk`\n{red ${e.message}}`);
     }
     throw e;
   }

--- a/src/commands/metadata.js
+++ b/src/commands/metadata.js
@@ -79,7 +79,7 @@ async function setContractMetadata(archwayd, cargo, options = {}) {
 
   await retry(
     async bail => {
-      const { code, raw_log: rawLog } = await archwayd.query.tx(txhash, { node, printStdout: false });
+      const { code, raw_log: rawLog } = await archwayd.query.tx(txhash, { node });
       if (code && code !== 0) {
         const error = new Error(rawLog);
         bail(error);
@@ -115,7 +115,6 @@ async function main(archwayd, options = {}) {
       console.warn(chalk`{yellow ${e.message}}`);
     } else {
       console.error(chalk`\n{red.bold Failed to set contract metadata}`);
-      console.error(chalk`{red ${e.message}}`);
     }
     throw e;
   }

--- a/src/commands/query.js
+++ b/src/commands/query.js
@@ -9,7 +9,6 @@ async function parseQueryOptions(config, { name: projectName }, { args, flags = 
   if (!_.isEmpty(args) && !isJson(args)) {
     throw new Error(`Arguments should be a JSON string, received "${args}"`);
   }
-  const printStdout = true;
   const { chainId, urls: { rpc } = {}, gas = {} } = config.get('network', {});
   const node = `${rpc.url}:${rpc.port}`;
   const { address: lastDeployedContract } = config.deployments.findLastByTypeAndProjectAndChainId('instantiate', projectName, chainId) || {};
@@ -31,7 +30,6 @@ async function parseQueryOptions(config, { name: projectName }, { args, flags = 
     node,
     gas,
     flags: [...flags],
-    printStdout
   };
 }
 
@@ -53,9 +51,8 @@ async function main(archwayd, { module, type, options }) {
       console.warn(chalk`{yellow ${e.message}}`);
     } else {
       console.error(chalk`\n{red.bold Failed to query transaction}`);
-      console.error(e);
-      throw new Error(e);
     }
+    throw e;
   }
 }
 

--- a/src/commands/store.js
+++ b/src/commands/store.js
@@ -113,7 +113,7 @@ async function storeWasm(archwayd, config, { project: { name: projectName, wasm:
     throw new Error(`Transaction failed: code=${code}, ${rawLog}`);
   }
   const codeIdString = await retry(
-    () => archwayd.query.txEventAttribute(txhash, 'store_code', 'code_id', { node, printStdout: false }),
+    () => archwayd.query.txEventAttribute(txhash, 'store_code', 'code_id', { node }),
     { text: chalk`Waiting for tx {cyan ${txhash}} to confirm...` }
   );
   const codeId = _.toNumber(codeIdString);
@@ -153,7 +153,6 @@ async function main(archwayd, options = {}) {
       console.warn(chalk`{yellow ${e.message}}`);
     } else {
       console.error(chalk`\n{red.bold Failed to store contract}`);
-      console.error(chalk`\n{red ${e.message}}`);
     }
     throw e;
   }

--- a/src/commands/tx.js
+++ b/src/commands/tx.js
@@ -57,7 +57,7 @@ async function executeTx(archwayd, cargo, options) {
   const { txhash } = await archwayd.tx.wasm('execute', [contract, args], { node, ...txOptions });
   await retry(
     async bail => {
-      const { code, raw_log: rawLog } = await archwayd.query.tx(txhash, { node, printStdout: false });
+      const { code, raw_log: rawLog } = await archwayd.query.tx(txhash, { node });
       if (code && code !== 0) {
         const error = new Error(rawLog);
         bail(error);


### PR DESCRIPTION
This fixes an error that outputs archwayd's stderr to the console while running commands that require waiting for a tx result (like `store` and `instantiate`).