### PR TITLE
fix: throw message with real message instead of hardcoded text for be…

### DIFF
--- a/src/clients/wasm_optimizer.js
+++ b/src/clients/wasm_optimizer.js
@@ -36,7 +36,7 @@ class WasmOptimizer {
     try {
       await this.#docker.ping();
     } catch (e) {
-      throw new Error('Docker is not running. Please start Docker and try again.');
+      throw new Error(e);
     }
 
     const image = await this.#fetchImage(isWorkspace);


### PR DESCRIPTION
To facilitate better troubleshooting and resolution by users, it is recommended to throw an error message that accurately reflects the specific issue at hand, rather than using hardcoded text.
I experienced a situation where my Docker container was operational, but I encountered a hardcoded error that left me puzzled and hindered my ability to solve the actual issue.
