### PR TITLE
fix(archwayd): don't freeze the shell

### DIFF
--- a/src/clients/archwayd/index.js
+++ b/src/clients/archwayd/index.js
@@ -109,6 +109,13 @@ class ArchwayClient {
       if (printStdout) {
         archwayd.stdout?.pipe(process.stdout);
         archwayd.stderr?.pipe(process.stderr);
+      } else {
+        // When the passphrase is requested by archwayd, we want to print it to stdout
+        archwayd.stdout?.on('data', data => {
+          if (data.toString().includes('passphrase')) {
+            process.stdout.write(data);
+          }
+        });
       }
 
       const { stdout } = await archwayd;
@@ -117,7 +124,8 @@ class ArchwayClient {
       const jsonOutput = jsonLines.pop() || '{}';
       return JSON.parse(jsonOutput);
     } catch (e) {
-      throw new ArchwayClientError(e.stderr);
+      const error = e.stderr || e.message;
+      throw new ArchwayClientError(error);
     }
   }
 

--- a/src/clients/archwayd/index.js
+++ b/src/clients/archwayd/index.js
@@ -110,12 +110,14 @@ class ArchwayClient {
         archwayd.stdout?.pipe(process.stdout);
         archwayd.stderr?.pipe(process.stderr);
       } else {
-        archwayd.stdout?.on('data', data => {
-          // When the passphrase is requested by archwayd, we want to print it to stdout
-          const message = data.toString().toLowerCase();
-          if (message.includes('passphrase') || message.includes('error')) {
-            process.stdout.write(data);
-          }
+        [archwayd.stdout, archwayd.stderr].forEach(stream => {
+          stream?.on('data', data => {
+            // When the passphrase is requested by archwayd, we want to print it to stdout
+            const message = data.toString().toLowerCase();
+            if (message.includes('passphrase') || message.includes('error')) {
+              process.stdout.write(data);
+            }
+          });
         });
       }
 

--- a/src/clients/archwayd/index.js
+++ b/src/clients/archwayd/index.js
@@ -110,9 +110,10 @@ class ArchwayClient {
         archwayd.stdout?.pipe(process.stdout);
         archwayd.stderr?.pipe(process.stderr);
       } else {
-        // When the passphrase is requested by archwayd, we want to print it to stdout
         archwayd.stdout?.on('data', data => {
-          if (data.toString().includes('passphrase')) {
+          // When the passphrase is requested by archwayd, we want to print it to stdout
+          const message = data.toString().toLowerCase();
+          if (message.includes('passphrase') || message.includes('error')) {
             process.stdout.write(data);
           }
         });

--- a/src/clients/archwayd/tx.js
+++ b/src/clients/archwayd/tx.js
@@ -37,11 +37,7 @@ class TxCommands {
       ...gasFlags,
       ...flags,
     ];
-    return await this.#client.runJson('tx', args, {
-      stdio: ['inherit', 'pipe', 'inherit'],
-      printStdout: false,
-      ...options,
-    });
+    return await this.#client.runJson('tx', args, { printStdout: false, ...options });
   }
 
   async #getGasFlags({ mode = 'auto', prices: defaultGasPrices, adjustment = 1.2 }, options) {

--- a/src/clients/archwayd/tx.js
+++ b/src/clients/archwayd/tx.js
@@ -6,40 +6,47 @@ class TxCommands {
   }
 
   async wasm(wasmCommand, wasmArgs, options) {
-    return await this.#runJson([
-      'wasm', wasmCommand, ...wasmArgs,
-    ], options);
+    return await this.#runJson(['wasm', wasmCommand, ...wasmArgs], options);
   }
 
   async setContractMetadata(contract, { ownerAddress, rewardsAddress }, options) {
-    return await this.#runJson([
-      'rewards', 'set-contract-metadata', contract,
-      ...(ownerAddress ? ['--owner-address', ownerAddress] : []),
-      ...(rewardsAddress ? ['--rewards-address', rewardsAddress] : []),
-    ], options);
+    return await this.#runJson(
+      [
+        'rewards',
+        'set-contract-metadata',
+        contract,
+        ...(ownerAddress ? ['--owner-address', ownerAddress] : []),
+        ...(rewardsAddress ? ['--rewards-address', rewardsAddress] : []),
+      ],
+      options
+    );
   }
 
   async #runJson(txArgs = [], { gas = {}, from, chainId, node, flags = [], ...options } = {}) {
     const gasFlags = await this.#getGasFlags(gas, { node });
     const args = [
       ...txArgs,
-      '--from', from,
-      '--chain-id', chainId,
-      '--node', node,
-      '--broadcast-mode', 'sync',
+      '--from',
+      from,
+      '--chain-id',
+      chainId,
+      '--node',
+      node,
+      '--broadcast-mode',
+      'sync',
       ...gasFlags,
-      ...flags
+      ...flags,
     ];
-    return await this.#client.runJson('tx', args, { printStdout: false, ...options });
+    return await this.#client.runJson('tx', args, {
+      stdio: ['inherit', 'pipe', 'inherit'],
+      printStdout: false,
+      ...options,
+    });
   }
 
   async #getGasFlags({ mode = 'auto', prices: defaultGasPrices, adjustment = 1.2 }, options) {
-    const gasPrices = await this.#getMinimumConsensusFee(options) || defaultGasPrices;
-    return [
-      '--gas', mode,
-      '--gas-prices', gasPrices,
-      '--gas-adjustment', adjustment,
-    ];
+    const gasPrices = (await this.#getMinimumConsensusFee(options)) || defaultGasPrices;
+    return ['--gas', mode, '--gas-prices', gasPrices, '--gas-adjustment', adjustment];
   }
 
   async #getMinimumConsensusFee(options) {


### PR DESCRIPTION
Since the Archway CLI wraps `archwayd` commands, if the binary requested for a passphrase to unlock the keyring, this output would be muted by the Archway CLI, causing the impression that the command was frozen, when it was actually waiting for an input.

This PR fixes this behavior by printing any passphrase related messages instead of supressing them.

Closes #168