### PR TITLE
feat(accounts): store the private key on the keyring (1/2)

### DIFF
--- a/archway-cli.json
+++ b/archway-cli.json
@@ -1,5 +1,0 @@
-{
-  "name": "archway-cli",
-  "chainId": "constantine-3",
-  "contractsPath": "./contracts"
-}

--- a/archway-cli.json
+++ b/archway-cli.json
@@ -1,0 +1,5 @@
+{
+  "name": "archway-cli",
+  "chainId": "constantine-3",
+  "contractsPath": "./contracts"
+}

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   "dependencies": {
     "@archwayhq/arch3.js": "^0.4.0",
     "@archwayhq/keyring-go": "^0.1.1",
+    "@cosmjs/amino": "^0.31.0",
     "@cosmjs/cosmwasm-stargate": "^0.31.1",
     "@cosmjs/crypto": "^0.31.0",
     "@cosmjs/encoding": "^0.31.0",

--- a/src/commands/accounts/new.ts
+++ b/src/commands/accounts/new.ts
@@ -1,7 +1,7 @@
-import { Flags } from '@oclif/core';
+import { Args, Flags } from '@oclif/core';
 
 import { BaseCommand } from '@/lib/base';
-import { AccountOptionalArg } from '@/parameters/arguments';
+import { ParamsAccountOptionalArg, StdinInputArg } from '@/parameters/arguments';
 import { Accounts, Config } from '@/domain';
 import { KeyringFlags } from '@/parameters/flags';
 import { bold, green, greenBright, yellow } from '@/utils';
@@ -16,11 +16,11 @@ import { Account, AccountType } from '@/types';
 export default class AccountsNew extends BaseCommand<typeof AccountsNew> {
   static summary = 'Adds a new wallet to the keystore';
   static args = {
-    'account-name': AccountOptionalArg,
+    'account-name': Args.string({ ...ParamsAccountOptionalArg, ignoreStdin: true }),
+    stdinInput: StdinInputArg,
   };
 
   static flags = {
-    mnemonic: Flags.string({ description: 'Wallet mnemonic (seed phrase)' }),
     ledger: Flags.boolean({ description: 'Add an account from a ledger device' }),
     ...KeyringFlags,
   };
@@ -39,7 +39,7 @@ export default class AccountsNew extends BaseCommand<typeof AccountsNew> {
     const account = await accountsDomain.new(
       this.args['account-name'] || (await Prompts.newAccount()),
       type,
-      this.flags.mnemonic
+      this.args.stdinInput
     );
 
     await this.successMessage(account);
@@ -52,7 +52,7 @@ export default class AccountsNew extends BaseCommand<typeof AccountsNew> {
       this.success(`${green('Account')} ${greenBright(account.name)} successfully created!`);
       this.log(`\nAddress: ${greenBright(account.address)}\n`);
       this.log(Accounts.prettyPrintPublicKey(account.publicKey));
-      if (account.type === AccountType.LOCAL) {
+      if (account.type === AccountType.LOCAL && account.mnemonic) {
         this.log(`\n${bold('Mnemonic:')} ${account.mnemonic}\n`);
         this.warning(
           `${yellow('Important:')} write this mnemonic phrase in a safe place. It is the ${bold(

--- a/src/commands/accounts/new.ts
+++ b/src/commands/accounts/new.ts
@@ -3,7 +3,7 @@ import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '@/lib/base';
 import { ParamsAccountOptionalArg, StdinInputArg } from '@/parameters/arguments';
 import { Accounts, Config } from '@/domain';
-import { KeyringFlags } from '@/parameters/flags';
+import { HdPathOptionalFlag, KeyringFlags } from '@/parameters/flags';
 import { bold, green, greenBright, yellow } from '@/utils';
 import { Prompts } from '@/services';
 
@@ -22,6 +22,11 @@ export default class AccountsNew extends BaseCommand<typeof AccountsNew> {
 
   static flags = {
     ledger: Flags.boolean({ description: 'Add an account from a ledger device' }),
+    recover: Flags.boolean({
+      description:
+        'Enables the recovery of an account from a mnemonic or a private key, received via the stdin, for example: cat ./key.txt | archway accounts new --recover',
+    }),
+    'hd-path': HdPathOptionalFlag,
     ...KeyringFlags,
   };
 
@@ -39,7 +44,8 @@ export default class AccountsNew extends BaseCommand<typeof AccountsNew> {
     const account = await accountsDomain.new(
       this.args['account-name'] || (await Prompts.newAccount()),
       type,
-      this.args.stdinInput
+      this.flags.recover ? this.args.stdinInput : undefined,
+      this.flags['hd-path']
     );
 
     await this.successMessage(account);

--- a/src/domain/Accounts.ts
+++ b/src/domain/Accounts.ts
@@ -156,12 +156,12 @@ export class Accounts {
    * Get a single account by name or address with its signer, if not provided will ask for it on a prompt.
    * Throws error if the account is not found
    *
-   * @param nameOrAddress - Account name or account address to search by
+   * @param nameOrAddress - Optional - Account name or account address to search by
    * @param defaultAccount - Optional - Default account name or account address
    * @param prefix - Optional - Bech 32 prefix for the address, defaults to 'archway'
    * @returns Promise containing an instance of {@link AccountWithSigner}
    */
-  async getWithSigner(nameOrAddress: string, defaultAccount?: string, prefix = DEFAULT_ADDRESS_BECH_32_PREFIX): Promise<AccountWithSigner> {
+  async getWithSigner(nameOrAddress?: string, defaultAccount?: string, prefix = DEFAULT_ADDRESS_BECH_32_PREFIX): Promise<AccountWithSigner> {
     let searchAccount = nameOrAddress || defaultAccount;
 
     if (!searchAccount) searchAccount = await Prompts.fromAccount();

--- a/src/domain/Accounts.ts
+++ b/src/domain/Accounts.ts
@@ -154,16 +154,17 @@ export class Accounts {
    * Get a single account by name or address with its signer, if not provided will ask for it on a prompt.
    * Throws error if the account is not found
    *
-   * @param nameOrAddress - Optional - Account name or account address to search by
+   * @param nameOrAddress - Account name or account address to search by
    * @param defaultAccount - Optional - Default account name or account address
+   * @param prefix - Optional - Bech 32 prefix for the address, defaults to 'archway'
    * @returns Promise containing an instance of {@link AccountWithSigner}
    */
-  async getWithSigner(nameOrAddress?: string, defaultAccount?: string): Promise<AccountWithSigner> {
+  async getWithSigner(nameOrAddress: string, defaultAccount?: string, prefix = DEFAULT_ADDRESS_BECH_32_PREFIX): Promise<AccountWithSigner> {
     let searchAccount = nameOrAddress || defaultAccount;
 
     if (!searchAccount) searchAccount = await Prompts.fromAccount();
 
-    const account = await this.keystore.getWithSigner(searchAccount);
+    const account = await this.keystore.getWithSigner(searchAccount, prefix);
 
     if (!account) throw new NotFoundError('Account', nameOrAddress);
 
@@ -221,12 +222,13 @@ export class Accounts {
    * Create an instance of {@link AccountBase} from an address, getting the name if found in keyring
    *
    * @param address - Account address to search by
+   * @param prefix - Optional - Bech 32 prefix for the address, defaults to 'archway'
    * @returns Promise containing an instance of {@link AccountBase}
    */
-  async accountBaseFromAddress(address: string): Promise<AccountBase> {
+  async accountBaseFromAddress(address: string, prefix = DEFAULT_ADDRESS_BECH_32_PREFIX): Promise<AccountBase> {
     const found = await this.keystore.findNameAndAddressInList(address);
 
-    if (!found) assertIsValidAddress(address, DEFAULT_ADDRESS_BECH_32_PREFIX);
+    if (!found) assertIsValidAddress(address, prefix);
 
     return {
       name: found?.name || '',

--- a/src/domain/Accounts.ts
+++ b/src/domain/Accounts.ts
@@ -1,5 +1,6 @@
 import ow from 'ow';
 import { Coin, StargateClient } from '@cosmjs/stargate';
+import { HdPath } from '@cosmjs/crypto';
 
 import { InvalidFormatError, NotFoundError } from '@/exceptions';
 import { Config, FileKeystore, KeystoreBackend, OsKeystore, TestKeystore } from '@/domain';
@@ -129,11 +130,12 @@ export class Accounts {
    *
    * @param name - Account name
    * @param type - {@link AccountType} value
-   * @param mnemonic - Optional - 24 word mnemonic to use in the new account
+   * @param mnemonicOrPrivateKey - Optional - Existing mnemonic or private key to use for the new account
+   * @param hdPath - Optional - HD path of the account
    * @returns Promise containing an instance of {@link Account}
    */
-  async new(name: string, type: AccountType, mnemonic?: string): Promise<Account> {
-    return this._keystore.add(name, type, mnemonic);
+  async new(name: string, type: AccountType, mnemonicOrPrivateKey?: string, hdPath?: HdPath): Promise<Account> {
+    return this._keystore.add(name, type, mnemonicOrPrivateKey, hdPath);
   }
 
   /**

--- a/src/domain/FileKeystore.ts
+++ b/src/domain/FileKeystore.ts
@@ -2,6 +2,7 @@ import keyring from '@archwayhq/keyring-go';
 import path from 'node:path';
 import { DirectSecp256k1HdWallet, DirectSecp256k1Wallet } from '@cosmjs/proto-signing';
 import { fromBase64 } from '@cosmjs/encoding';
+import { HdPath } from '@cosmjs/crypto';
 
 import { InvalidPasswordError } from '@/exceptions';
 import { Prompts } from '@/services';
@@ -27,9 +28,9 @@ export class FileKeystore extends KeystoreBackend {
   /**
    * {@inheritDoc KeystoreBackend.add}
    */
-  async add(name: string, type: AccountType, mnemonic?: string): Promise<Account> {
+  async add(name: string, type: AccountType, mnemonicOrPrivateKey?: string, hdPath?: HdPath): Promise<Account> {
     const password = await this.promptPassword(name);
-    const account = await this.createAccountObject(name, type, mnemonic, password);
+    const account = await this.createAccountObject(name, type, mnemonicOrPrivateKey, hdPath);
 
     keyring.FileStore.set(
       this.filesPath,

--- a/src/domain/FileKeystore.ts
+++ b/src/domain/FileKeystore.ts
@@ -32,10 +32,12 @@ export class FileKeystore extends KeystoreBackend {
     const password = await this.promptPassword(name);
     const account = await this.createAccountObject(name, type, mnemonicOrPrivateKey, hdPath);
 
+    const serializedPrivateKey = await this.serializePrivateKey(account.privateKey!, password);
+
     keyring.FileStore.set(
       this.filesPath,
       this.createEntryTag(account.name, account.type, account.address),
-      JSON.stringify({ ...account, mnemonic: undefined }),
+      JSON.stringify({ ...account, privateKey: JSON.stringify(serializedPrivateKey), mnemonic: undefined }),
       password
     );
 
@@ -79,10 +81,12 @@ export class FileKeystore extends KeystoreBackend {
         const deserialized = await DirectSecp256k1HdWallet.deserialize(result.mnemonic, result.address);
         const privateKey = await this.convertMnemonicToPrivateKey(deserialized.mnemonic);
 
+        const serializedPrivateKey = await this.serializePrivateKey(privateKey, password);
+
         result = {
           ...result,
           mnemonic: undefined,
-          privateKey,
+          privateKey: JSON.stringify(serializedPrivateKey),
         };
 
         keyring.OsStore.set(this.filesPath, tag, JSON.stringify(result));
@@ -90,8 +94,13 @@ export class FileKeystore extends KeystoreBackend {
 
       this.assertIsValidAccountWithPrivateKey(result);
 
+      const serializedKey = JSON.parse(result.privateKey);
+      this.assertIsValidSerializedKey(serializedKey, result.name);
+
+      const deserializedPrivateKey = await this.deserializePrivateKey(serializedKey, password);
+
       const signer =
-        result.type === AccountType.LEDGER ? undefined : await DirectSecp256k1Wallet.fromKey(fromBase64(result.privateKey), prefix);
+        result.type === AccountType.LEDGER ? undefined : await DirectSecp256k1Wallet.fromKey(fromBase64(deserializedPrivateKey), prefix);
 
       return {
         account: { ...result, mnemonic: undefined, privateKey: undefined },

--- a/src/domain/KeystoreBackend.ts
+++ b/src/domain/KeystoreBackend.ts
@@ -1,11 +1,22 @@
-import { DirectSecp256k1HdWallet } from '@cosmjs/proto-signing';
-import { toBase64 } from '@cosmjs/encoding';
+import { DirectSecp256k1HdWallet, DirectSecp256k1Wallet } from '@cosmjs/proto-signing';
+import { fromBase64, toBase64 } from '@cosmjs/encoding';
+import { Bip39, EnglishMnemonic, Slip10, Slip10Curve } from '@cosmjs/crypto';
+import ow from 'ow';
 
 import { Ledger } from '@/domain';
 import { DEFAULT_ADDRESS_BECH_32_PREFIX, ENTRY_SUFFIX, ENTRY_TAG_SEPARATOR } from './Accounts';
-import { AlreadyExistsError, NotFoundError } from '@/exceptions';
+import { AlreadyExistsError, InvalidFormatError, NotFoundError } from '@/exceptions';
+import { makeCosmosDerivationPath } from '@/utils';
 
-import { Account, AccountBase, AccountType, AccountWithSigner } from '@/types';
+import {
+  Account,
+  AccountBase,
+  AccountType,
+  AccountWithSigner,
+  accountValidator,
+  accountWithMnemonicValidator,
+  accountWithPrivateKeyValidator,
+} from '@/types';
 
 /**
  * Abstract definition to be used on different KeystoreBackend implementations
@@ -31,9 +42,10 @@ export abstract class KeystoreBackend {
    * Get a single account by name or address, including mnemonic
    *
    * @param nameOrAddress - Account name or account address to search by
+   * @param prefix - Optional - Bech 32 prefix for the address, defaults to 'archway'
    * @returns Promise containing the account's data and signer, or undefined if it doesn't exist
    */
-  abstract getWithSigner(nameOrAddress: string): Promise<AccountWithSigner | undefined>;
+  abstract getWithSigner(nameOrAddress: string, prefix: string): Promise<AccountWithSigner | undefined>;
 
   /**
    * Remove an account by name or address
@@ -67,10 +79,11 @@ export abstract class KeystoreBackend {
    * Get a single account by name or address
    *
    * @param nameOrAddress - Account name or account address to search by
+   * @param prefix - Optional - Bech 32 prefix for the address, defaults to 'archway'
    * @returns Promise containing the account's data, or undefined if it doesn't exist
    */
-  async get(nameOrAddress: string): Promise<Account | undefined> {
-    let found = await this.getWithSigner(nameOrAddress);
+  async get(nameOrAddress: string, prefix = DEFAULT_ADDRESS_BECH_32_PREFIX): Promise<Account | undefined> {
+    let found = await this.getWithSigner(nameOrAddress, prefix);
 
     if (found?.account) {
       const result: Account = {
@@ -87,12 +100,26 @@ export abstract class KeystoreBackend {
   }
 
   /**
+   * Convert a mnemonic into a single account private key. Derivation path can be passed as a parameter.
+   *
+   * @param mnemonic - Mnemonic to convert
+   * @param hdPath - Optional - Derivation path to get the account that will be extracted. Defaults to `m/44'/118'/0'/0/0`
+   * @param bip39Password - Optional - Password used to generate the seed
+   * @returns Promise containing the private key in base64 encoding
+   */
+  protected async convertMnemonicToPrivateKey(mnemonic: string, hdPath = makeCosmosDerivationPath(), bip39Password = ''): Promise<string> {
+    const seed = await Bip39.mnemonicToSeed(new EnglishMnemonic(mnemonic), bip39Password);
+    const { privkey } = Slip10.derivePath(Slip10Curve.Secp256k1, seed, hdPath);
+
+    return toBase64(privkey);
+  }
+
+  /**
    * Create a new {@link Account}, can be from ledger, or from mnemonic
    *
    * @param name - Account name
    * @param type - {@link AccountType} value
-   * @param mnemonic - Optional - Existing {@link Account} to be validated
-   * @param password - Optional - Password for serialization of the mnemonic
+   * @param mnemonicOrPrivateKey - Optional - Existing {@link Account} to be validated
    * @param prefix - Optional - Bech 32 prefix for the generated address, defaults to 'archway'
    * @returns Promise containing the {@link Account}
    */
@@ -100,8 +127,7 @@ export abstract class KeystoreBackend {
   protected async createAccountObject(
     name: string,
     type: AccountType,
-    mnemonic?: string,
-    password?: string,
+    mnemonicOrPrivateKey?: string,
     prefix = DEFAULT_ADDRESS_BECH_32_PREFIX
   ): Promise<Account> {
     let result: Account;
@@ -109,9 +135,17 @@ export abstract class KeystoreBackend {
     if (type === AccountType.LEDGER) {
       result = await Ledger.getAccount(name);
     } else {
-      const wallet = await (mnemonic ?
-        DirectSecp256k1HdWallet.fromMnemonic(mnemonic, { prefix }) :
+      const hdWallet = await (mnemonicOrPrivateKey ?
+        (mnemonicOrPrivateKey.includes(' ') ?
+          DirectSecp256k1HdWallet.fromMnemonic(mnemonicOrPrivateKey, { prefix }) :
+          undefined) :
         DirectSecp256k1HdWallet.generate(24, { prefix }));
+
+      const mnemonic = hdWallet?.mnemonic;
+
+      const privateKey = mnemonic ? await this.convertMnemonicToPrivateKey(mnemonic) : mnemonicOrPrivateKey!;
+
+      const wallet = await DirectSecp256k1Wallet.fromKey(fromBase64(privateKey), prefix);
 
       const newAccount = (await wallet.getAccounts())[0];
 
@@ -123,7 +157,8 @@ export abstract class KeystoreBackend {
           key: toBase64(newAccount.pubkey),
         },
         type: AccountType.LOCAL,
-        mnemonic: await wallet.serialize(password || newAccount.address),
+        mnemonic,
+        privateKey,
       };
     }
 
@@ -132,6 +167,39 @@ export abstract class KeystoreBackend {
 
     return result;
   }
+
+  /**
+   * Verify if an object has the valid format of a {@link Account} (including the private key except for ledger accounts), throws error if not
+   *
+   * @param data - Object instance to validate
+   * @param name - Optional - Name of the account, will be used in the possible error
+   * @returns void
+   */
+  protected assertIsValidAccountWithPrivateKey = (data: unknown, name?: string): void => {
+    if (!this.isValidAccountWithPrivateKey(data)) throw new InvalidFormatError(name || 'Account');
+  };
+
+  /**
+   * Verify if an object has the valid format of a {@link Account} (including private key, except for ledger accounts)
+   *
+   * @param data - Object instance to validate
+   * @returns Boolean, whether it is valid or not
+   */
+  protected isValidAccountWithPrivateKey = (data: unknown): boolean => {
+    return (data as any).type === AccountType.LEDGER ?
+      ow.isValid(data, accountValidator) :
+      ow.isValid(data, accountWithPrivateKeyValidator);
+  };
+
+  /**
+   * Verify if an object has the valid format of a {@link Account} (including mnemonic, except for ledger accounts)
+   *
+   * @param data - Object instance to validate
+   * @returns Boolean, whether it is valid or not
+   */
+  protected isValidAccountWithMnemonic = (data: unknown): boolean => {
+    return (data as any).type === AccountType.LEDGER ? ow.isValid(data, accountValidator) : ow.isValid(data, accountWithMnemonicValidator);
+  };
 
   /**
    * Check if an account exists by name or address, if not found throws an error

--- a/src/domain/Ledger.ts
+++ b/src/domain/Ledger.ts
@@ -1,34 +1,15 @@
 /* eslint-disable unicorn/no-static-only-class */
 import TransportNodeHid from '@ledgerhq/hw-transport-node-hid';
 import { LedgerSigner } from '@cosmjs/ledger-amino';
-import { HdPath, Slip10RawIndex } from '@cosmjs/crypto';
 import { toBase64 } from '@cosmjs/encoding';
 
 import { DEFAULT_ADDRESS_BECH_32_PREFIX } from './Accounts';
+import { makeCosmosDerivationPath } from '@/utils';
 
 import { Account, AccountType } from '@/types';
 
 const LISTEN_TIMEOUT = 120_000;
 const OPEN_TIMEOUT = 120_000;
-
-/**
- * Creates a BIP44 compatible derivation path
- *
- * @param coinType - Optional - Defaults to 118 which is the standard cosmos coinType
- * @param account - Optional - Defaults to 0
- * @param change  - Optional - Defaults to 0
- * @param index  - Optional - Defaults to 0
- * @returns Array containing the derivation path values
- */
-export function makeCosmosDerivationPath(coinType = 118, account = 0, change = 0, index = 0): HdPath {
-  return [
-    Slip10RawIndex.hardened(44),
-    Slip10RawIndex.hardened(coinType),
-    Slip10RawIndex.hardened(account),
-    Slip10RawIndex.normal(change),
-    Slip10RawIndex.normal(index),
-  ];
-}
 
 /**
  * Manages communication with a Ledger device

--- a/src/domain/OsKeystore.ts
+++ b/src/domain/OsKeystore.ts
@@ -1,6 +1,7 @@
 import keyring from '@archwayhq/keyring-go';
 import { DirectSecp256k1HdWallet, DirectSecp256k1Wallet } from '@cosmjs/proto-signing';
 import { fromBase64 } from '@cosmjs/encoding';
+import { HdPath } from '@cosmjs/crypto';
 
 import { InvalidPasswordError } from '@/exceptions';
 import { DEFAULT_ADDRESS_BECH_32_PREFIX } from './Accounts';
@@ -22,8 +23,8 @@ export class OsKeystore extends KeystoreBackend {
   /**
    * {@inheritDoc KeystoreBackend.add}
    */
-  async add(name: string, type: AccountType, mnemonic?: string): Promise<Account> {
-    const account = await this.createAccountObject(name, type, mnemonic);
+  async add(name: string, type: AccountType, mnemonicOrPrivateKey?: string, hdPath?: HdPath): Promise<Account> {
+    const account = await this.createAccountObject(name, type, mnemonicOrPrivateKey, hdPath);
 
     keyring.OsStore.set(
       this.serviceName,

--- a/src/domain/TestKeystore.ts
+++ b/src/domain/TestKeystore.ts
@@ -2,6 +2,7 @@ import keyring from '@archwayhq/keyring-go';
 import path from 'node:path';
 import { DirectSecp256k1HdWallet, DirectSecp256k1Wallet } from '@cosmjs/proto-signing';
 import { fromBase64 } from '@cosmjs/encoding';
+import { HdPath } from '@cosmjs/crypto';
 
 import { DEFAULT_ADDRESS_BECH_32_PREFIX, TEST_ENTRY_SUFFIX } from './Accounts';
 import { KeystoreBackend } from './KeystoreBackend';
@@ -25,8 +26,8 @@ export class TestKeystore extends KeystoreBackend {
   /**
    * {@inheritDoc KeystoreBackend.add}
    */
-  async add(name: string, type: AccountType, mnemonic?: string): Promise<Account> {
-    const account = await this.createAccountObject(name, type, mnemonic);
+  async add(name: string, type: AccountType, mnemonicOrPrivateKey?: string, hdPath?: HdPath): Promise<Account> {
+    const account = await this.createAccountObject(name, type, mnemonicOrPrivateKey, hdPath);
 
     keyring.UnencryptedFileStore.set(
       this.filesPath,

--- a/src/parameters/flags/account.ts
+++ b/src/parameters/flags/account.ts
@@ -1,0 +1,28 @@
+import { Flags } from '@oclif/core';
+import { HdPath } from '@cosmjs/crypto';
+
+import { makeCosmosDerivationPath } from '@/utils';
+
+const HdPathFlagDescription = 'HD path of the account, numbers separated by / (Defaults to 118/0/0/0)';
+
+/**
+ * Definition of Amount optional flag
+ */
+export const ParamsHdPathOptionalFlag = {
+  description: HdPathFlagDescription,
+  parse: async (val: string): Promise<HdPath> => {
+    const received = val
+      .split('/')
+      .map(item => Number(item))
+      .filter(Boolean);
+
+    const pathValues = [...Array.from({ length: 4 - received.length }), ...received];
+
+    return makeCosmosDerivationPath(...(pathValues as Array<number | undefined>));
+  },
+};
+
+/**
+ * Hd Path optional flag
+ */
+export const HdPathOptionalFlag = Flags.custom<HdPath>(ParamsHdPathOptionalFlag)();

--- a/src/parameters/flags/index.ts
+++ b/src/parameters/flags/index.ts
@@ -1,3 +1,4 @@
+export * from './account';
 export * from './amount';
 export * from './chain';
 export * from './config';

--- a/src/types/Account.ts
+++ b/src/types/Account.ts
@@ -1,5 +1,5 @@
 import ow from 'ow';
-import { DirectSecp256k1HdWallet } from '@cosmjs/proto-signing';
+import { DirectSecp256k1Wallet } from '@cosmjs/proto-signing';
 
 import { Coin } from '@/types';
 
@@ -18,11 +18,12 @@ export interface AccountBase {
 }
 
 /**
- * Account information (with optional mnemonic)
+ * Account information (with optional mnemonic or private key)
  */
 export interface Account extends AccountBase {
   publicKey: PublicKey;
   mnemonic?: string;
+  privateKey?: string;
 }
 
 /**
@@ -30,7 +31,7 @@ export interface Account extends AccountBase {
  */
 export interface AccountWithSigner {
   account: Account,
-  signer?: DirectSecp256k1HdWallet;
+  signer?: DirectSecp256k1Wallet;
 }
 
 /**
@@ -86,6 +87,7 @@ const AccountShape = {
   publicKey: publicKeyValidator,
   type: ow.string.oneOf(Object.values(AccountType)),
   mnemonic: ow.optional.string,
+  privateKey: ow.optional.string,
 };
 
 /**
@@ -100,3 +102,12 @@ export const accountWithMnemonicValidator = ow.object.exactShape({
   ...AccountShape,
   mnemonic: ow.string,
 });
+
+/**
+ * Format validator for the {@link Account} interface, with mandatory private key value
+ */
+export const accountWithPrivateKeyValidator = ow.object.exactShape({
+  ...AccountShape,
+  privateKey: ow.string,
+});
+

--- a/src/types/Account.ts
+++ b/src/types/Account.ts
@@ -1,11 +1,12 @@
 import ow from 'ow';
 import { DirectSecp256k1Wallet } from '@cosmjs/proto-signing';
+import { KdfConfiguration } from '@cosmjs/amino';
 
 import { Coin } from '@/types';
 
 export enum AccountType {
   LOCAL = 'local',
-  LEDGER = 'ledger'
+  LEDGER = 'ledger',
 }
 
 /**
@@ -30,7 +31,7 @@ export interface Account extends AccountBase {
  * Account with signer
  */
 export interface AccountWithSigner {
-  account: Account,
+  account: Account;
   signer?: DirectSecp256k1Wallet;
 }
 
@@ -68,6 +69,18 @@ export interface AccountBalancesJSON {
 export interface AccountsParams {
   serviceName?: string;
   filesPath?: string;
+}
+
+/**
+ * Serialized key with kdf and encryption information
+ */
+export interface SerializedKey {
+  type: string;
+  kdf: KdfConfiguration;
+  encryption: {
+    algorithm: string;
+  };
+  data: string;
 }
 
 /**
@@ -111,3 +124,21 @@ export const accountWithPrivateKeyValidator = ow.object.exactShape({
   privateKey: ow.string,
 });
 
+/**
+ * Format validator for the {@link Account} interface, with mandatory private key value
+ */
+export const argonXchachaSerializedKeyValidator = ow.object.exactShape({
+  type: ow.string.equals('private-key'),
+  kdf: {
+    algorithm: ow.string.equals('argon2id'),
+    params: {
+      outputLength: ow.number,
+      opsLimit: ow.number,
+      memLimitKib: ow.number,
+    },
+  },
+  encryption: {
+    algorithm: ow.string.equals('xchacha20poly1305-ietf'),
+  },
+  data: ow.string,
+});

--- a/src/utils/accounts.ts
+++ b/src/utils/accounts.ts
@@ -1,4 +1,5 @@
 import { bech32 } from 'bech32';
+import { HdPath, Slip10RawIndex } from '@cosmjs/crypto';
 
 import { InvalidFormatError } from '@/exceptions';
 
@@ -37,3 +38,22 @@ export const isValidAddress = (address: string, prefix?: string): boolean => {
 
   return false;
 };
+
+/**
+ * Creates a BIP44 compatible derivation path
+ *
+ * @param coinType - Optional - Defaults to 118 which is the standard cosmos coinType
+ * @param account - Optional - Defaults to 0
+ * @param change  - Optional - Defaults to 0
+ * @param index  - Optional - Defaults to 0
+ * @returns Array containing the derivation path values
+ */
+export function makeCosmosDerivationPath(coinType = 118, account = 0, change = 0, index = 0): HdPath {
+  return [
+    Slip10RawIndex.hardened(44),
+    Slip10RawIndex.hardened(coinType),
+    Slip10RawIndex.hardened(account),
+    Slip10RawIndex.normal(change),
+    Slip10RawIndex.normal(index),
+  ];
+}

--- a/test/commands/accounts/new.test.ts
+++ b/test/commands/accounts/new.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@oclif/test';
 
-import { aliceAccountName, aliceMnemonic } from '../../dummies';
+import { aliceAccountName, aliceAddress, aliceMnemonic } from '../../dummies';
 import { AccountsStubs } from '../../stubs';
 
 describe('accounts new', () => {
@@ -27,9 +27,21 @@ describe('accounts new', () => {
 
     test
       .stdout()
-      .command(['accounts new', aliceAccountName, `--mnemonic=${aliceMnemonic}`])
+      .command(['accounts new', aliceAccountName, `${aliceMnemonic}`, '--recover'])
       .it('creates a new account using mnemonic passed in flag', ctx => {
         expect(ctx.stdout).to.contain(aliceAccountName);
+        expect(ctx.stdout).to.contain(aliceAddress);
+        expect(ctx.stdout).to.contain('successfully created');
+        expect(ctx.stdout).to.contain('Mnemonic:');
+        expect(ctx.stdout).to.contain(aliceMnemonic);
+      });
+
+    test
+      .stdout()
+      .command(['accounts new', aliceAccountName, `${aliceMnemonic}`, '--recover', '--hd-path=2'])
+      .it('creates a new account using mnemonic and with a different hd path', ctx => {
+        expect(ctx.stdout).to.contain(aliceAccountName);
+        expect(ctx.stdout).to.not.contain(aliceAddress);
         expect(ctx.stdout).to.contain('successfully created');
         expect(ctx.stdout).to.contain('Mnemonic:');
         expect(ctx.stdout).to.contain(aliceMnemonic);

--- a/test/integration/accounts.sh
+++ b/test/integration/accounts.sh
@@ -25,7 +25,7 @@ output="$(archway accounts remove ${ALICE} --force --keyring-backend test --json
 output="$(archway accounts remove ${BOB} --force --keyring-backend test --json || true)"
 
 printf "\n***** accounts new ***** \n"
-output="$(archway accounts new ${ALICE} --mnemonic "$ALICE_MNEMONIC" --keyring-backend test --json)"
+output="$(echo "$ALICE_MNEMONIC" | archway accounts new ${ALICE} --recover --keyring-backend test --json)"
 validate "$output" ".name == \"${ALICE}\" and has(\"address\") and (.publicKey | has(\"key\")) and .mnemonic == \"${ALICE_MNEMONIC}\""
 
 output="$(archway accounts new ${BOB} --keyring-backend test --json)"

--- a/test/integration/utils.sh
+++ b/test/integration/utils.sh
@@ -66,7 +66,7 @@ function useLocalChain() {
 function createAlice() {
   echo "Recreating Alice Account"
   archway accounts remove ${ALICE} --force --keyring-backend test --json || true
-  archway accounts new ${ALICE} --mnemonic "$ALICE_MNEMONIC" --keyring-backend test --json
+  echo "$ALICE_MNEMONIC" | archway accounts new ${ALICE} --recover --keyring-backend test --json
 }
 
 function getAliceAddress() {


### PR DESCRIPTION
Also changed the value stored in the keystore from mnemonic based to private key based.
This will not break existing alpha.1 created accounts, it will migrate them to the new format.

Improvements based on #211 