### PR TITLE
fix: add other aliases for version flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "typescript": "^5.0.4"
   },
   "oclif": {
+    "additionalVersionFlags": ["version", "v", "-v"],
     "bin": "archway",
     "dirname": "archway",
     "commands": "./dist/commands",

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -1,12 +1,11 @@
-import { Command } from '@oclif/core';
-
-import Help from '@/plugins/help-plugin/help';
+import { BaseCommand } from '@/lib/base';
+import HelpPlugin from '@/plugins/help-plugin/help';
 
 /**
  * Command 'help'
  * Displays the help info
  */
-export default class Config extends Command {
+export default class Help extends BaseCommand<typeof Help> {
   static summary = 'Display help for archway.';
 
   /**
@@ -15,7 +14,7 @@ export default class Config extends Command {
    * @returns Empty promise
    */
   public async run(): Promise<void> {
-    const help = new Help(this.config, { all: true });
+    const help = new HelpPlugin(this.config, { all: true });
     await help.showHelp(this.argv);
   }
 }


### PR DESCRIPTION
Add `version`, `v`, and `-v` aliases for the version display command.

Minor refactoring: updated the base class used on the `help` command.