### PR TITLE
feat(config): add command to list available chains

### DIFF
--- a/src/commands/config/chain-id.ts
+++ b/src/commands/config/chain-id.ts
@@ -1,10 +1,10 @@
 /* eslint-disable unicorn/filename-case */
 import { Args } from '@oclif/core';
 
-import { BaseCommand } from '@/lib/base';
-import { bold, greenBright, reset } from '@/utils';
 import { ChainRegistry, Config, DEFAULT_CONFIG_DATA } from '@/domain';
+import { BaseCommand } from '@/lib/base';
 import { GlobalFlag } from '@/parameters/flags';
+import { bold, greenBright, reset } from '@/utils';
 
 /**
  * Command 'config chain-id'
@@ -39,7 +39,7 @@ export default class ConfigChainId extends BaseCommand<typeof ConfigChainId> {
 
       await this.successMessage(chainId, global);
     } else {
-      const currentValue = global ? configFile.globalConfigData['chain-id'] : configFile.localConfigData['chain-id'];
+      const currentValue = global ? configFile.globalData['chain-id'] : configFile.localData['chain-id'];
       this.log(greenBright(currentValue || `Empty, defaults to: ${reset.bold(DEFAULT_CONFIG_DATA['chain-id'])}`));
 
       if (this.jsonEnabled()) this.logJson({ 'chain-id': currentValue || '' });

--- a/src/commands/config/chains/list.ts
+++ b/src/commands/config/chains/list.ts
@@ -1,0 +1,78 @@
+import { ChainRegistry, Config } from '@/domain';
+import { BaseCommand } from '@/lib/base';
+import { ux } from '@oclif/core';
+
+export type ChainData = Record<string, string | number | boolean>;
+
+/**
+ * Command 'config chains list'
+ * Lists all available chains to use
+ */
+export default class ConfigChainsList extends BaseCommand<typeof ConfigChainsList> {
+  static summary = 'Lists all available chains to use';
+
+  static flags = {
+    ...ux.table.flags({ except: ['csv', 'output'] }),
+  }
+
+  /**
+   * Runs the command.
+   *
+   * @returns Empty promise
+   */
+  public async run(): Promise<readonly ChainData[]> {
+    const config = await Config.init();
+    const chainRegistry = await ChainRegistry.init();
+
+    const { flags } = await this.parse(ConfigChainsList)
+
+    const chainsData = chainRegistry.chains.map(chain => {
+      const {
+        chain_id: chainId,
+        chain_name: chainName,
+        pretty_name: prettyName,
+        fees: { fee_tokens: [{ denom: feeDenom }] = [] } = {},
+        apis: { rpc: [{ address: rpcUrl }] = [] } = {},
+      } = chain;
+
+      return {
+        current: config.chainId === chainId,
+        chainId,
+        chainName: prettyName || chainName,
+        feeDenom,
+        rpcUrl
+      }
+    });
+
+    if (!this.jsonEnabled()) {
+      if (chainRegistry.warnings) {
+        this.warning(chainRegistry.prettyPrintWarnings(this.args.chain))
+      }
+
+      ux.table(chainsData, {
+        current: {
+          header: 'Current',
+          get: ({ current }) => current ? '   ✓' : '',
+        },
+        chainId: {
+          header: 'Chain ID',
+        },
+        chainName: {
+          header: 'Name',
+        },
+        feeDenom: {
+          header: 'Fee Denom',
+          extended: true,
+        },
+        rpcUrl: {
+          header: 'RPC URL',
+          extended: true,
+        },
+      }, {
+        ...flags,
+      });
+    }
+
+    return chainsData;
+  }
+}

--- a/src/commands/config/contracts-path.ts
+++ b/src/commands/config/contracts-path.ts
@@ -1,10 +1,10 @@
 /* eslint-disable unicorn/filename-case */
 import { Args } from '@oclif/core';
 
-import { BaseCommand } from '@/lib/base';
-import { bold, greenBright, reset } from '@/utils';
 import { Config, DEFAULT_CONFIG_DATA } from '@/domain';
+import { BaseCommand } from '@/lib/base';
 import { GlobalFlag } from '@/parameters/flags';
+import { bold, greenBright, reset } from '@/utils';
 
 /**
  * Command 'config contracts-path'
@@ -36,7 +36,7 @@ export default class ConfigContractsPath extends BaseCommand<typeof ConfigContra
 
       await this.successMessage(contractsPath, global);
     } else {
-      const currentValue = global ? configFile.globalConfigData['contracts-path'] : configFile.localConfigData['contracts-path'];
+      const currentValue = global ? configFile.globalData['contracts-path'] : configFile.localData['contracts-path'];
       this.log(greenBright(currentValue || `Empty, defaults to: ${reset.bold(DEFAULT_CONFIG_DATA['contracts-path'])}`));
 
       if (this.jsonEnabled()) this.logJson({ 'contracts-path': currentValue || '' });

--- a/src/commands/config/default-account.ts
+++ b/src/commands/config/default-account.ts
@@ -1,10 +1,10 @@
 /* eslint-disable unicorn/filename-case */
 import { Args } from '@oclif/core';
 
-import { BaseCommand } from '@/lib/base';
-import { bold, greenBright, reset } from '@/utils';
 import { Config } from '@/domain';
+import { BaseCommand } from '@/lib/base';
 import { GlobalFlag } from '@/parameters/flags';
+import { bold, greenBright, reset } from '@/utils';
 
 /**
  * Command 'config default-account'
@@ -39,7 +39,7 @@ export default class ConfigDefaultAccount extends BaseCommand<typeof ConfigDefau
 
       await this.successMessage(defaultAccount, global);
     } else {
-      const currentValue = global ? configFile.globalConfigData['default-account'] : configFile.localConfigData['default-account'];
+      const currentValue = global ? configFile.globalData['default-account'] : configFile.localData['default-account'];
       this.log(greenBright(currentValue || `Empty, ${reset.bold('default-account')} is not set`));
 
       if (this.jsonEnabled()) this.logJson({ 'default-account': currentValue || '' });

--- a/src/commands/config/init.ts
+++ b/src/commands/config/init.ts
@@ -28,6 +28,6 @@ export default class ConfigInit extends BaseCommand<typeof ConfigInit> {
   protected async successMessage(config: Config): Promise<void> {
     this.success(`${green('Config file')} ${bold(LOCAL_CONFIG_FILE)} ${green('created')}`);
 
-    if (this.jsonEnabled()) this.logJson(config.localConfigData);
+    if (this.jsonEnabled()) this.logJson(config.localData);
   }
 }

--- a/src/commands/config/keyring-backend.ts
+++ b/src/commands/config/keyring-backend.ts
@@ -1,11 +1,11 @@
 /* eslint-disable unicorn/filename-case */
 import { Args } from '@oclif/core';
 
-import { BaseCommand } from '@/lib/base';
-import { bold, greenBright, reset } from '@/utils';
 import { Config, DEFAULT_CONFIG_DATA } from '@/domain';
+import { BaseCommand } from '@/lib/base';
 import { GlobalFlag } from '@/parameters/flags';
 import { KeystoreBackendType } from '@/types';
+import { bold, greenBright, reset } from '@/utils';
 
 /**
  * Command 'config keyring-backend'
@@ -42,7 +42,7 @@ export default class ConfigKeyringBackend extends BaseCommand<typeof ConfigKeyri
 
       await this.successMessage(keyringBackend, global);
     } else {
-      const currentValue = global ? configFile.globalConfigData['keyring-backend'] : configFile.localConfigData['keyring-backend'];
+      const currentValue = global ? configFile.globalData['keyring-backend'] : configFile.localData['keyring-backend'];
       this.log(greenBright(currentValue || `Empty, defaults to: ${reset.bold(DEFAULT_CONFIG_DATA['keyring-backend'])}`));
 
       if (this.jsonEnabled()) this.logJson({ 'keyring-backend': currentValue || '' });

--- a/src/commands/config/keyring-path.ts
+++ b/src/commands/config/keyring-path.ts
@@ -1,11 +1,11 @@
 /* eslint-disable unicorn/filename-case */
 import { Args } from '@oclif/core';
 
-import { BaseCommand } from '@/lib/base';
-import { bold, greenBright, reset } from '@/utils';
 import { Config, DEFAULT_CONFIG_DATA } from '@/domain';
+import { BaseCommand } from '@/lib/base';
 import { GlobalFlag } from '@/parameters/flags';
 import { KeystoreBackendType } from '@/types';
+import { bold, greenBright, reset } from '@/utils';
 
 /**
  * Command 'config keyring-path'
@@ -42,7 +42,7 @@ export default class ConfigKeyringPath extends BaseCommand<typeof ConfigKeyringP
 
       await this.successMessage(keyringPath, global);
     } else {
-      const currentValue = global ? configFile.globalConfigData['keyring-path'] : configFile.localConfigData['keyring-path'];
+      const currentValue = global ? configFile.globalData['keyring-path'] : configFile.localData['keyring-path'];
       this.log(greenBright(currentValue || `Empty, defaults to: ${reset.bold(DEFAULT_CONFIG_DATA['keyring-path'])}`));
 
       if (this.jsonEnabled()) this.logJson({ 'keyring-path': currentValue || '' });

--- a/src/domain/ChainRegistry.ts
+++ b/src/domain/ChainRegistry.ts
@@ -17,24 +17,24 @@ export const CHAIN_FILE_EXTENSION = '.json';
  * Manages the chains in the project, including the built-in and the imported ones.
  */
 export class ChainRegistry extends ChainRegistrySpec {
-  private _data: CosmosChain[];
+  private _chains: CosmosChain[];
   private _dirPath: string;
   private _warnings: ChainWarning[];
 
   /**
-   * @param data - List of the {@link CosmosChain} representation of the chains in the project
+   * @param chains - List of the {@link CosmosChain} representation of the chains in the project
    * @param dirPath - Absolute path of the imported chain config files
    * @param warning - List of warnings related to the chain config files
    */
-  constructor(data: CosmosChain[], dirPath: string, warning: ChainWarning[]) {
+  constructor(chains: CosmosChain[], dirPath: string, warning: ChainWarning[]) {
     super();
-    this._data = data;
+    this._chains = chains;
     this._dirPath = dirPath;
     this._warnings = warning;
   }
 
-  get listChains(): CosmosChain[] {
-    return this._data;
+  get chains(): CosmosChain[] {
+    return this._chains;
   }
 
   get dirPath(): string {
@@ -159,7 +159,7 @@ export class ChainRegistry extends ChainRegistrySpec {
    * @returns The {@link CosmosChain} that matches the id, or undefined if not found
    */
   getChainById(chainId: string): CosmosChain | undefined {
-    return this._data.find(item => item.chain_id === chainId);
+    return this._chains.find(item => item.chain_id === chainId);
   }
 
   /**
@@ -192,7 +192,7 @@ export class ChainRegistry extends ChainRegistrySpec {
     if (this._warnings) this._warnings = this._warnings.filter(item => item.filename !== newChainId);
 
     // Add to inner data
-    this._data = this._data.map(item => (item.chain_id === newChainId ? chain : item));
+    this._chains = this._chains.map(item => (item.chain_id === newChainId ? chain : item));
   }
 
   /**

--- a/src/domain/Config.ts
+++ b/src/domain/Config.ts
@@ -98,38 +98,38 @@ export class Config {
     return this._contracts.deployments.listDeployments();
   }
 
-  get globalConfigData(): ConfigData {
+  get globalData(): ConfigData {
     return this._globalConfigData;
   }
 
-  get localConfigData(): ConfigData {
+  get localData(): ConfigData {
     return this._localConfigData;
   }
 
   /** Returns the resolved version with precedence of local \> global \> default */
-  get configData(): ConfigData {
+  get data(): ConfigData {
     return _.merge(DEFAULT_CONFIG_DATA, this._globalConfigData, this._localConfigData);
   }
 
   /** Getters for the fields from ConfigData */
   get chainId(): string {
-    return this.configData['chain-id']!;
+    return this.data['chain-id']!;
   }
 
   get contractsPath(): string {
-    return this.configData['contracts-path']!;
+    return this.data['contracts-path']!;
   }
 
   get keyringBackend(): KeystoreBackendType {
-    return this.configData['keyring-backend']!;
+    return this.data['keyring-backend']!;
   }
 
   get keyringPath(): string {
-    return this.configData['keyring-path']!;
+    return this.data['keyring-path']!;
   }
 
   get defaultAccount(): string | undefined {
-    return this.configData['default-account'];
+    return this.data['default-account'];
   }
 
   /**
@@ -404,7 +404,7 @@ export class Config {
    */
   async dataWithContracts(): Promise<ConfigDataWithContracts> {
     return {
-      ...this.configData,
+      ...this.data,
       contracts: this.contractsInstance.listContracts(),
     };
   }

--- a/src/lib/base.ts
+++ b/src/lib/base.ts
@@ -75,7 +75,7 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
       return;
     }
 
-    this.log(`${yellow(WARNING_PREFIX)} ${message}`);
+    this.logToStderr(`${yellow(WARNING_PREFIX)} ${message}`);
   }
 
   /**

--- a/src/services/Prompts.ts
+++ b/src/services/Prompts.ts
@@ -21,7 +21,7 @@ export class Prompts {
   static async chain(): Promise<string> {
     const chainRegistry = await ChainRegistry.init();
 
-    const choices = chainRegistry.listChains.map((item: CosmosChain) => {
+    const choices = chainRegistry.chains.map((item: CosmosChain) => {
       return {
         title: item?.pretty_name || item?.chain_name || '',
         description: ChainPromptDetails[item.chain_id]?.description,

--- a/src/types/Chain.ts
+++ b/src/types/Chain.ts
@@ -5,7 +5,7 @@ import ow from 'ow';
  * Abstract definition to be used on ChainRegistry class
  */
 export abstract class ChainRegistrySpec {
-  abstract get listChains(): CosmosChain[];
+  abstract get chains(): CosmosChain[];
 
   abstract import(chainInfo: CosmosChain): Promise<void>;
 }

--- a/test/commands/accounts/remove.test.ts
+++ b/test/commands/accounts/remove.test.ts
@@ -34,9 +34,10 @@ describe('accounts remove', () => {
     });
     test
       .stdout()
+      .stderr()
       .command(['accounts remove', aliceAccountName])
       .it("doesn't delete the account", ctx => {
-        expect(ctx.stdout).to.contain('Operation canceled');
+        expect(ctx.stderr).to.contain('Operation canceled');
         expect(ctx.stdout).to.not.contain('deleted');
       });
   });

--- a/test/commands/config/chains.test.ts
+++ b/test/commands/config/chains.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@oclif/test';
 
 import ConfigChains from '../../../src/commands/config/chains';
+import { ChainData } from '../../../src/commands/config/chains/list';
 import { chainString } from '../../dummies';
 import { ConfigStubs, FilesystemStubs } from '../../stubs';
 
@@ -59,6 +60,26 @@ describe('config chains', () => {
       .it('updates config file to use chain', ctx => {
         expect(ctx.stdout).to.contain('Switched chain to');
         expect(filesystemStubs.stubbedWriteFile?.called).to.be.true;
+      });
+  });
+
+  describe('list', () => {
+    test
+      .stdout()
+      .command(['config chains list'])
+      .it('lists all available chains', ctx => {
+        expect(ctx.stdout).to.contain('Current');
+        expect(ctx.stdout).to.contain('Chain ID');
+        expect(ctx.stdout).to.contain('Name');
+        expect(ctx.stdout).to.contain('constantine-3');
+        expect(ctx.stdout).to.contain('archway-1');
+
+        const returned = ctx.returned as readonly ChainData[];
+        expect(returned.length).to.be.gte(2);
+
+        const chainIds = returned.map(({ current, chainId }) => ({ current, chainId }));
+        expect(chainIds).to.deep.contain({ current: true, chainId: 'constantine-3' });
+        expect(chainIds).to.deep.contain({ current: false, chainId: 'archway-1' });
       });
   });
 


### PR DESCRIPTION
## New command

`archway config chains list`

```console
$ archway config chains list --help
Description:
  Lists all available chains to use

Usage:
  $ archway config chains list [--json] [--log-level debug|info|warn|error] [--columns <value> | -x] [--sort <value>] [--filter <value>] [--no-truncate | ] [--no-header | ]

Flags:
  -x, --extended     show extra columns
  --columns=<value>  only show provided columns (comma-separated)
  --filter=<value>   filter property by partial string matching, ex: name=foo
  --no-header        hide table header from output
  --no-truncate      do not truncate output to fit screen
  --sort=<value>     property to sort by (prepend '-' for descending)

GLOBAL Flags:
  --json                Format output as json.
  --log-level=<option>  Specify level for logging.
                        <options: debug|info|warn|error>

Examples:
  $ archway config chains list
```